### PR TITLE
Simplify the simple-db.

### DIFF
--- a/exercise-book/src/SUMMARY.md
+++ b/exercise-book/src/SUMMARY.md
@@ -8,10 +8,10 @@
   - [Fizzbuzz Cheat-Sheet](./fizzbuzz-cheat-sheet.md)
 - [Fizzbuzz with match](./fizzbuzz-match.md)
 - [Rust Latin](./rustlatin.md)
+- [URLs, match, result](./urls-match-result.md)
 - [SimpleDB](./simple-db.md)
   - [Knowledge](./simple-db-knowledge.md)
   - [Step-by-Step Solution](./simple-db-solution.md)
-- [URLs, match, result](./urls-match-result.md)
 
 # Applied Rust
 

--- a/exercise-book/src/simple-db-knowledge.md
+++ b/exercise-book/src/simple-db-knowledge.md
@@ -17,7 +17,7 @@ This enables automatic debug output for the type. The `assert_eq!`macro requires
 
 ## Control flow and pattern matching, returning values
 
-This exercise involves handling a number of cases. You are already familiar with `if /else` and a basic form of `match`. Here, we’ll introduce you to `if let`.
+This exercise involves handling a number of cases. You are already familiar with `if/else` and a basic form of `match`. Here, we’ll introduce you to `if let`.
 
 ```rust, ignore
     if let Some(payload) = substrings.next() {
@@ -25,17 +25,13 @@ This exercise involves handling a number of cases. You are already familiar with
     }
 ```
 
-`if let` assigns and evaluates in one line. A typical use is to assign the returned `Option(T)` from a method to `Some(T)`. The statement yields true, if `Some(T)` is returned, false if `None` is returned.
 
 ### When to use what?
 
-`if let` is used if you have to decide between two cases, where the
-second case is usually of lesser meaning for the program’s execution.
+`if let` is like a pattern-matching `match` block with only one arm. So, if your `match` only has one arm of interest, consider an `if let` instead.
 
-`match` can be used to handle more fine grained and complex pattern matching, especially when there are several, equally ranked possibilities. The match arms have to include a catch all `_ =>` arm, for every possible case that is not explicitly spelled out. The order of the match arms matter: The catch all branch needs to be last, otherwise, it catches all…
+`match` can be used to handle more fine grained and complex pattern matching, especially when there are several, equally ranked possibilities. The match arms may have to include a catch all `_ =>` arm, for every possible case that is not explicitly spelled out. The order of the match arms matter: The catch all branch needs to be last, otherwise, it catches all…
 
 ### Returning Values from branches and match arms
 
-- all match arms always need to return the same type, or none can return a value.
-
-- For `if let/else` or `if/else`: If there is no explicit `else` branch, it implicitly returns `()`. If you run into trouble because you need a return type, but don’t need the else condition, `return` statements can help.
+All match arms always need to produce a value the same type (or they diverge with a `return` statement).

--- a/exercise-book/src/simple-db-solution.md
+++ b/exercise-book/src/simple-db-solution.md
@@ -138,52 +138,7 @@ If all else fails, feel free to copy this solution to play around with it.
   <summary>Solution</summary>
 
 ```rust
-#[derive(Eq, PartialEq, Debug)]
-pub enum Command {
-    Publish(String),
-    Retrieve,
-}
-
-#[derive(Eq, PartialEq, Debug)]
-pub enum Error {
-    TrailingData,
-    IncompleteMessage,
-    EmptyMessage,
-    UnknownCommand,
-    UnexpectedPayload,
-    MissingPayload,
-}
-
-pub fn parse(input: &str) -> Result<Command, Error> {
-    let message = match input.split_once('\n') {
-        Some((message, "")) => message,
-        Some(_) => return Err(Error::TrailingData),
-        None => return Err(Error::IncompleteMessage),
-    };
-
-    let mut substrings = message.splitn(2, ' ');
-
-    // Note: `splitn` *always* returns at least one value
-    let command = substrings.next().unwrap();
-    match command {
-        "RETRIEVE" => {
-            if substrings.next().is_none() {
-                Ok(Command::Retrieve)
-            } else {
-                Err(Error::UnexpectedPayload)
-            }
-        }
-        "PUBLISH" => {
-            if let Some(payload) = substrings.next() {
-                Ok(Command::Publish(String::from(payload)))
-            } else {
-                Err(Error::MissingPayload)
-            }
-        }
-        "" => Err(Error::EmptyMessage),
-        _ => Err(Error::UnknownCommand),
-    }
-}
+{{#include ../../exercise-solutions/simple-db/step4e/src/lib.rs}}
 ```
 
 </details>

--- a/exercise-book/src/simple-db.md
+++ b/exercise-book/src/simple-db.md
@@ -25,7 +25,7 @@ In this exercise, we will implement a toy protocol parser for a simple protocol 
 
 1. Create a library project called `simple-db`.
 2. Implement appropriate data structures for `Command` and `Error`.
-3. Read the documentation for `str` (primitive), especially [`split_once()`](https://doc.rust-lang.org/std/primitive.str.html#method.split_once), [`splitn()`](https://doc.rust-lang.org/std/primitive.str.html#method.splitn) and [`trim()`](https://doc.rust-lang.org/std/primitive.str.html#method.trim). Pay attention to their return type. Use the result value of `split_once()` and `splitn()` to guide your logic. The Step-by-Step-Solution contains a proposal.
+3. Read the documentation for `str` (primitive), especially [`split_once()`](https://doc.rust-lang.org/std/primitive.str.html#method.split_once) and [`splitn()`](https://doc.rust-lang.org/std/primitive.str.html#method.splitn). Pay attention to their return type. Use the result value of `split_once()` and `splitn()` to guide your logic. The Step-by-Step-Solution contains a proposal.
 4. Implement the following function so that it implements the protocol specifications to parse the messages. Use the provided tests to help you with the case handling.
 
 ```rust, ignore
@@ -78,8 +78,6 @@ handled with the following error codes:
 - UnexpectedPayload (message contains a payload, when it should not)
 
 - MissingPayload (message is missing a payload)
-
-- UnknownError (message does not contain a string)
 
 ### Testing
 

--- a/exercise-solutions/connected-mailbox/simple-db/src/lib.rs
+++ b/exercise-solutions/connected-mailbox/simple-db/src/lib.rs
@@ -30,38 +30,134 @@ pub enum Error {
     MissingPayload,
 }
 
+/// Parse a command-string into `Command`, or produce an `Error` if it could not
+/// be parsed.
 pub fn parse(input: &str) -> Result<Command, Error> {
-    match input.split_once('\n') {
-        Some((_message, trailing_data)) => {
-            if !trailing_data.is_empty() {
-                return Err(Error::TrailingData);
+    let message = match input.split_once('\n') {
+        Some((message, "")) => message,
+        Some(_) => return Err(Error::TrailingData),
+        None => return Err(Error::IncompleteMessage),
+    };
+
+    let mut substrings = message.splitn(2, ' ');
+
+    // Note: `splitn` *always* returns at least one value
+    let command = substrings.next().unwrap();
+    match command {
+        "RETRIEVE" => {
+            if substrings.next().is_none() {
+                Ok(Command::Retrieve)
+            } else {
+                Err(Error::UnexpectedPayload)
             }
         }
-        None => return Err(Error::IncompleteMessage),
+        "PUBLISH" => {
+            if let Some(payload) = substrings.next() {
+                Ok(Command::Publish(String::from(payload)))
+            } else {
+                Err(Error::MissingPayload)
+            }
+        }
+        "" => Err(Error::EmptyMessage),
+        _ => Err(Error::UnknownCommand),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests placement of \n
+    #[test]
+    fn test_missing_nl() {
+        let line = "RETRIEVE";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Err(Error::IncompleteMessage);
+        assert_eq!(result, expected);
+    }
+    #[test]
+    fn test_trailing_data() {
+        let line = "PUBLISH The message\n is wrong \n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Err(Error::TrailingData);
+        assert_eq!(result, expected);
     }
 
-    let mut substrings = input.splitn(2, ' ');
+    #[test]
+    fn test_empty_string() {
+        let line = "";
+        let result = parse(line);
+        let expected = Err(Error::IncompleteMessage);
+        assert_eq!(result, expected);
+    }
 
-    if let Some(command) = substrings.next() {
-        match command.trim() {
-            "RETRIEVE" => {
-                if substrings.next().is_none() {
-                    Ok(Command::Retrieve)
-                } else {
-                    Err(Error::UnexpectedPayload)
-                }
-            }
-            "PUBLISH" => {
-                if let Some(payload) = substrings.next() {
-                    Ok(Command::Publish(String::from(payload.trim())))
-                } else {
-                    Err(Error::MissingPayload)
-                }
-            }
-            "" => Err(Error::EmptyMessage),
-            _ => Err(Error::UnknownCommand),
-        }
-    } else {
-        Err(Error::IncompleteMessage)
+    // Tests for empty messages and unknown commands
+
+    #[test]
+    fn test_only_nl() {
+        let line = "\n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Err(Error::EmptyMessage);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_unknown_command() {
+        let line = "SERVE \n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Err(Error::UnknownCommand);
+        assert_eq!(result, expected);
+    }
+
+    // Tests correct formatting of RETRIEVE command
+
+    #[test]
+    fn test_retrieve_w_whitespace() {
+        let line = "RETRIEVE \n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Err(Error::UnexpectedPayload);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_retrieve_payload() {
+        let line = "RETRIEVE this has a payload\n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Err(Error::UnexpectedPayload);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_retrieve() {
+        let line = "RETRIEVE\n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Ok(Command::Retrieve);
+        assert_eq!(result, expected);
+    }
+
+    // Tests correct formatting of PUBLISH command
+
+    #[test]
+    fn test_publish() {
+        let line = "PUBLISH TestMessage\n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Ok(Command::Publish("TestMessage".into()));
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_empty_publish() {
+        let line = "PUBLISH \n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Ok(Command::Publish("".into()));
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_missing_payload() {
+        let line = "PUBLISH\n";
+        let result: Result<Command, Error> = parse(line);
+        let expected = Err(Error::MissingPayload);
+        assert_eq!(result, expected);
     }
 }

--- a/exercise-solutions/simple-db/step2/src/lib.rs
+++ b/exercise-solutions/simple-db/step2/src/lib.rs
@@ -10,7 +10,6 @@ pub enum Error {
     IncompleteMessage,
     EmptyMessage,
     UnknownCommand,
-    UnknownError,
     UnexpectedPayload,
     MissingPayload,
 }

--- a/exercise-solutions/simple-db/step4a/src/lib.rs
+++ b/exercise-solutions/simple-db/step4a/src/lib.rs
@@ -11,21 +11,15 @@ pub enum Error {
     IncompleteMessage,
     EmptyMessage,
     UnknownCommand,
-    UnknownError,
     UnexpectedPayload,
     MissingPayload,
 }
 
 pub fn parse(input: &str) -> Result<Command, Error> {
     match input.split_once('\n') {
-        Some((_message, trailing_data)) => {
-            if trailing_data.len() != 0 {
-                Err(Error::TrailingData)
-            } else {
-                Ok(Command::Command)
-            }
-        }
-        None => Err(Error::IncompleteMessage),
+        Some((_message, "")) => Ok(Command::Command),
+        Some(_) => return Err(Error::TrailingData),
+        None => return Err(Error::IncompleteMessage),
     }
 }
 

--- a/exercise-solutions/simple-db/step4b/src/lib.rs
+++ b/exercise-solutions/simple-db/step4b/src/lib.rs
@@ -11,28 +11,22 @@ pub enum Error {
     IncompleteMessage,
     EmptyMessage,
     UnknownCommand,
-    UnknownError,
     UnexpectedPayload,
     MissingPayload,
 }
 
 pub fn parse(input: &str) -> Result<Command, Error> {
-    match input.split_once('\n') {
-        Some((_message, trailing_data)) => {
-            if trailing_data.len() != 0 {
-                return Err(Error::TrailingData);
-            }
-        }
+    let message = match input.split_once('\n') {
+        Some((message, "")) => message,
+        Some(_) => return Err(Error::TrailingData),
         None => return Err(Error::IncompleteMessage),
-    }
+    };
 
-    let mut substrings = input.splitn(2, ' ');
+    let mut substrings = message.splitn(2, ' ');
 
-    if let Some(command) = substrings.next() {
-        Ok(Command::Command)
-    } else {
-        Err(Error::UnknownError)
-    }
+    let _command = substrings.next().unwrap();
+
+    Ok(Command::Command)
 }
 
 #[cfg(test)]

--- a/exercise-solutions/simple-db/step4c/src/lib.rs
+++ b/exercise-solutions/simple-db/step4c/src/lib.rs
@@ -10,30 +10,24 @@ pub enum Error {
     IncompleteMessage,
     EmptyMessage,
     UnknownCommand,
-    UnknownError,
     UnexpectedPayload,
     MissingPayload,
 }
 
 pub fn parse(input: &str) -> Result<Command, Error> {
-    match input.split_once('\n') {
-        Some((_message, trailing_data)) => {
-            if trailing_data.len() != 0 {
-                return Err(Error::TrailingData);
-            }
-        }
+    let message = match input.split_once('\n') {
+        Some((message, "")) => message,
+        Some(_) => return Err(Error::TrailingData),
         None => return Err(Error::IncompleteMessage),
-    }
+    };
 
-    let mut substrings = input.splitn(2, ' ');
+    let mut substrings = message.splitn(2, ' ');
 
-    if let Some(command) = substrings.next() {
-        match command.trim() {
-            "" => Err(Error::EmptyMessage),
-            _ => Err(Error::UnknownCommand),
-        }
-    } else {
-        Err(Error::UnknownError)
+    // Note: `splitn` *always* returns at least one value
+    let command = substrings.next().unwrap();
+    match command {
+        "" => Err(Error::EmptyMessage),
+        _ => Err(Error::UnknownCommand),
     }
 }
 

--- a/exercise-solutions/simple-db/step4d/src/lib.rs
+++ b/exercise-solutions/simple-db/step4d/src/lib.rs
@@ -10,37 +10,31 @@ pub enum Error {
     IncompleteMessage,
     EmptyMessage,
     UnknownCommand,
-    UnknownError,
     UnexpectedPayload,
     MissingPayload,
 }
 
 pub fn parse(input: &str) -> Result<Command, Error> {
-    match input.split_once('\n') {
-        Some((_message, trailing_data)) => {
-            if trailing_data.len() != 0 {
-                return Err(Error::TrailingData);
-            }
-        }
+    let message = match input.split_once('\n') {
+        Some((message, "")) => message,
+        Some(_) => return Err(Error::TrailingData),
         None => return Err(Error::IncompleteMessage),
-    }
+    };
 
-    let mut substrings = input.splitn(2, ' ');
+    let mut substrings = message.splitn(2, ' ');
 
-    if let Some(command) = substrings.next() {
-        match command.trim() {
-            "RETRIEVE" => {
-                if substrings.next().is_none() {
-                    Ok(Command::Retrieve)
-                } else {
-                    Err(Error::UnexpectedPayload)
-                }
+    // Note: `splitn` *always* returns at least one value
+    let command = substrings.next().unwrap();
+    match command {
+        "RETRIEVE" => {
+            if substrings.next().is_none() {
+                Ok(Command::Retrieve)
+            } else {
+                Err(Error::UnexpectedPayload)
             }
-            "" => Err(Error::EmptyMessage),
-            _ => Err(Error::UnknownCommand),
         }
-    } else {
-        Err(Error::UnknownError)
+        "" => Err(Error::EmptyMessage),
+        _ => Err(Error::UnknownCommand),
     }
 }
 

--- a/exercise-solutions/simple-db/step4e/src/lib.rs
+++ b/exercise-solutions/simple-db/step4e/src/lib.rs
@@ -10,44 +10,38 @@ pub enum Error {
     IncompleteMessage,
     EmptyMessage,
     UnknownCommand,
-    UnknownError,
     UnexpectedPayload,
     MissingPayload,
 }
 
 pub fn parse(input: &str) -> Result<Command, Error> {
-    match input.split_once('\n') {
-        Some((_message, trailing_data)) => {
-            if trailing_data.len() != 0 {
-                return Err(Error::TrailingData);
-            }
-        }
+    let message = match input.split_once('\n') {
+        Some((message, "")) => message,
+        Some(_) => return Err(Error::TrailingData),
         None => return Err(Error::IncompleteMessage),
-    }
+    };
 
-    let mut substrings = input.splitn(2, ' ');
+    let mut substrings = message.splitn(2, ' ');
 
-    if let Some(command) = substrings.next() {
-        match command.trim() {
-            "RETRIEVE" => {
-                if substrings.next().is_none() {
-                    Ok(Command::Retrieve)
-                } else {
-                    Err(Error::UnexpectedPayload)
-                }
+    // Note: `splitn` *always* returns at least one value
+    let command = substrings.next().unwrap();
+    match command {
+        "RETRIEVE" => {
+            if substrings.next().is_none() {
+                Ok(Command::Retrieve)
+            } else {
+                Err(Error::UnexpectedPayload)
             }
-            "PUBLISH" => {
-                if let Some(payload) = substrings.next() {
-                    Ok(Command::Publish(String::from(payload.trim())))
-                } else {
-                    Err(Error::MissingPayload)
-                }
-            }
-            "" => Err(Error::EmptyMessage),
-            _ => Err(Error::UnknownCommand),
         }
-    } else {
-        Err(Error::UnknownError)
+        "PUBLISH" => {
+            if let Some(payload) = substrings.next() {
+                Ok(Command::Publish(String::from(payload)))
+            } else {
+                Err(Error::MissingPayload)
+            }
+        }
+        "" => Err(Error::EmptyMessage),
+        _ => Err(Error::UnknownCommand),
     }
 }
 


### PR DESCRIPTION
The late trim() would allow some invalid inputs. Also, let's not handle the impossible case of splitn never returning anything.