### PR TITLE
Clean up the connected-db example.

### DIFF
--- a/exercise-templates/tcp-echo-server/src/main.rs
+++ b/exercise-templates/tcp-echo-server/src/main.rs
@@ -1,13 +1,8 @@
 use std::io::prelude::*;
 use std::net::{TcpListener, TcpStream};
+use std::time::Duration;
 
-fn handle_client(mut stream: TcpStream) -> Result<(), std::io::Error> {
-    let mut buffer = String::new();
-    stream.read_to_string(&mut buffer)?;
-    println!("Received: {:?}", buffer);
-    writeln!(stream, "Thank you for {buffer:?}!")?;
-    Ok(())
-}
+const DEFAULT_TIMEOUT: Option<Duration> = Some(Duration::from_millis(1000));
 
 fn main() -> std::io::Result<()> {
     let listener = TcpListener::bind("127.0.0.1:7878")?;
@@ -26,5 +21,19 @@ fn main() -> std::io::Result<()> {
             }
         }
     }
+    Ok(())
+}
+
+/// Process a single connection from a single client.
+///
+/// Drops the stream when it has finished.
+fn handle_client(mut stream: TcpStream) -> Result<(), std::io::Error> {
+    stream.set_read_timeout(DEFAULT_TIMEOUT)?;
+    stream.set_write_timeout(DEFAULT_TIMEOUT)?;
+
+    let mut buffer = String::new();
+    stream.read_to_string(&mut buffer)?;
+    println!("Received: {:?}", buffer);
+    writeln!(stream, "Thank you for {buffer:?}!")?;
     Ok(())
 }


### PR DESCRIPTION
1) A bad command from the user isn't an error the main thread needs to handle - that can go back to the client.
2) So you don't need the combo ServerError type.
3) Don't break read_command out - it prevents you accessing the string form of the command.
4) Move things around to tcp-echo-server and connected-mailbox/tcp-server look alike.
5) Add a short timeout, so slow clients can't lock us up for long periods.

Closes #20 