### PR TITLE
Remove duplicate tests.

### DIFF
--- a/exercise-solutions/simple-db/step4a/src/lib.rs
+++ b/exercise-solutions/simple-db/step4a/src/lib.rs
@@ -50,25 +50,4 @@ mod tests {
         let expected = Ok(Command::Command);
         assert_eq!(result, expected);
     }
-
-    #[cfg(test)]
-    mod tests {
-        use super::*;
-
-        // Tests placement of \n
-        #[test]
-        fn test_missing_nl() {
-            let line = "RETRIEVE";
-            let result: Result<Command, Error> = parse(line);
-            let expected = Err(Error::IncompleteMessage);
-            assert_eq!(result, expected);
-        }
-        #[test]
-        fn test_trailing_data() {
-            let line = "PUBLISH The message\n is wrong \n";
-            let result: Result<Command, Error> = parse(line);
-            let expected = Err(Error::TrailingData);
-            assert_eq!(result, expected);
-        }
-    }
 }


### PR DESCRIPTION
Solution Step 4a for simpleDB had the tests copy-pasted twice.