### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,3 +42,5 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: ./rust-exercises-${{ env.slug }}.zip
+          allowUpdates: true
+          updateOnlyUnreleased: true


### PR DESCRIPTION
Allow action to update an existing release.

Let you create tags by making a release, rather than manually tagging in the CLI.