### PR TITLE
Typo run

### DIFF
--- a/exercise-book/src/green-yellow-game.md
+++ b/exercise-book/src/green-yellow-game.md
@@ -125,7 +125,7 @@ You need a random number generator (call `rand::thread_rng()`), and using that y
 
 ### Reading from the Console
 
-You need to grab a standard input handle with `std::io::stdin()`. This implments the `std::io::Write` trait, so you can call `read_to_string(&mut some_string)` and get a line of text into your `some_string: String` variable.
+You need to grab a standard input handle with `std::io::stdin()`. This implements the `std::io::Write` trait, so you can call `read_to_string(&mut some_string)` and get a line of text into your `some_string: String` variable.
 
 ### Parsing Strings into Integers
 
@@ -144,7 +144,7 @@ Create a new binary Cargo project, check the build and see if it runs.
 
 ```shell
 cargo new green-yellow
-cd fizzbuzz 
+cd fizzbuzz
 cargo run
 ```
 

--- a/exercise-book/src/introduction.md
+++ b/exercise-book/src/introduction.md
@@ -23,7 +23,7 @@ We use Icons to mark different kinds of information in the book:
 
 ## Course Material
 
-We have attempted to make our material as inclusive as possible. This means, that some information is available in several forms, for example as a picture and as a text description. We also use icons so that different kinds of information are visually distiguishable on the first glance. If you are on a course and have accessibility needs that are not covered, please let us know.
+We have attempted to make our material as inclusive as possible. This means, that some information is available in several forms, for example as a picture and as a text description. We also use icons so that different kinds of information are visually distinguishable on the first glance. If you are on a course and have accessibility needs that are not covered, please let us know.
 
 ## License
 

--- a/exercise-book/src/multi-threaded-mailbox.md
+++ b/exercise-book/src/multi-threaded-mailbox.md
@@ -1,6 +1,6 @@
 # Multi-Threaded Mailbox Exercise
 
-In this exercise, we will take our "Conneted Mailbox" and make it multi-threaded. A new thread should be spawned for every incoming connection, and that thread should take ownership of the `TcpStream` and drive it to completion.
+In this exercise, we will take our "Connected Mailbox" and make it multi-threaded. A new thread should be spawned for every incoming connection, and that thread should take ownership of the `TcpStream` and drive it to completion.
 
 ## After completing this exercise you are able to
 
@@ -16,7 +16,7 @@ In this exercise, we will take our "Conneted Mailbox" and make it multi-threaded
 
 ## Tasks
 
-1. Use the `std::thread::spawn` API to start a new thead when your main loop produces a new connection to a client. The `handle_client` function should be executed within that spawned thread. Note how Rust doesn't let you pass `&mut VecDequeue<String>` into the spawned thread, both becuase you have multiple `&mut` references (not allowed) and because the thread might live longer than the `VecDeque` (which only lives whilst the `main()` function is running, and `main()` might quit at any time with an early return or a break out of the connection loop).
+1. Use the `std::thread::spawn` API to start a new thead when your main loop produces a new connection to a client. The `handle_client` function should be executed within that spawned thread. Note how Rust doesn't let you pass `&mut VecDequeue<String>` into the spawned thread, both because you have multiple `&mut` references (not allowed) and because the thread might live longer than the `VecDeque` (which only lives whilst the `main()` function is running, and `main()` might quit at any time with an early return or a break out of the connection loop).
 
 2. Convert the `VecDeque` into a `Arc<Mutex<VecDequeue>>` (use `std::sync::Mutex`). Change the `handle_client` function to take a `&Mutex<VecDeque>`. Clone the Arc handle with `.clone()` and `move` that cloned handle into the new thread. Change the `handle_client` function to call `let mut queue = your_mutex.lock().unwrap();` whenever you want to access the queue inside the Mutex.
 
@@ -119,7 +119,7 @@ fn main() {
 
 ## Creating a thread scope.
 
-The 
+The
 
 <details>
     <summary>Solution</summary>

--- a/exercise-book/src/nrf52-preparation.md
+++ b/exercise-book/src/nrf52-preparation.md
@@ -1,6 +1,6 @@
 # nRF52 Preparation
 
-This chapter contains informations about the nRF52-based exercises, the required hardware and an installation guide.
+This chapter contains information about the nRF52-based exercises, the required hardware and an installation guide.
 
 ## Required Hardware
 

--- a/exercise-book/src/rustlatin.md
+++ b/exercise-book/src/rustlatin.md
@@ -66,7 +66,7 @@ A part of this exercise is seeing type inference in action and to use it to help
 
 ### Step 1: Splitting a sentence and pushing its words into a vector.
 
-✅ Iterate over the sentence to split it into words. Use the white space as separator. This can be done with the [`.split()`](https://doc.rust-lang.org/std/primitive.str.html#method.split) method, where the separator character `' '` goes into the paranthesis. This method returns an iterator over substrings of the string slice. In Rust, iterators are lazy, that means just calling `.split()` on a `&str` doesn’t do anything by itself. It needs to be in combination with something that advances the iteration, such as a `for` loop, or a manual advancement such as the `.next()` method. These will yield the actual object you want to use. [Push](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.push) each word into the vector `collection_of_words`. Add the correct return type to the function signature.
+✅ Iterate over the sentence to split it into words. Use the white space as separator. This can be done with the [`.split()`](https://doc.rust-lang.org/std/primitive.str.html#method.split) method, where the separator character `' '` goes into the parenthesis. This method returns an iterator over substrings of the string slice. In Rust, iterators are lazy, that means just calling `.split()` on a `&str` doesn’t do anything by itself. It needs to be in combination with something that advances the iteration, such as a `for` loop, or a manual advancement such as the `.next()` method. These will yield the actual object you want to use. [Push](https://doc.rust-lang.org/std/vec/struct.Vec.html#method.push) each word into the vector `collection_of_words`. Add the correct return type to the function signature.
 
 ✅ Run the test to see if it passes.
 
@@ -87,11 +87,11 @@ fn rustlatin(sentence: &str) -> Vec<String> {
 
 ### Step 2: Concatenating String types.
 
-✅ After iterating over the sentence to split it into words, add the suffix `"rs"` to each word before pushing it to the vector. 
+✅ After iterating over the sentence to split it into words, add the suffix `"rs"` to each word before pushing it to the vector.
 
-✅ To concatenate two `&str` the first needs to be turned into the owned type with `.to_owned()`. Then `String` and `&str` can be added using `+`. 
+✅ To concatenate two `&str` the first needs to be turned into the owned type with `.to_owned()`. Then `String` and `&str` can be added using `+`.
 
-✅ Add the correct return type to the function signature. 
+✅ Add the correct return type to the function signature.
 
 ✅ Run the test to see if it passes.
 

--- a/exercise-book/src/simple-db-solution.md
+++ b/exercise-book/src/simple-db-solution.md
@@ -8,9 +8,9 @@ Create a new Cargo project, check the build and the test setup:
   <summary>Solution</summary>
 
 ```console
-cargo new --lib simple-db 
-cd simple-db 
-cargo build 
+cargo new --lib simple-db
+cd simple-db
+cargo build
 cargo test
 ```
 
@@ -38,15 +38,15 @@ tl;dr
 <details>
   <summary>The proposed logic</summary>
 
-Split the input with `split_once()` using `\n` as delimeter, this allows to distiguish 3 cases:
+Split the input with `split_once()` using `\n` as delimiter, this allows to distinguish 3 cases:
 
 - a command where `\n` is the last part, and the second substring is `""` -> some kind of command
 - a command with trailing data (i.e. data after a newline) -> Error::TrailingData
 - a command with no `\n` -> Error::IncompleteMessage
 
-After that, split the input with `splitn()` using `' '` as delimeter and 2 as the max number of substrings. The method an iterator over the substrings, and the iterator produces `Some(...)`, or `None` when there are no substrings. Note, that even an empty str `""` is a substring.
+After that, split the input with `splitn()` using `' '` as delimiter and 2 as the max number of substrings. The method an iterator over the substrings, and the iterator produces `Some(...)`, or `None` when there are no substrings. Note, that even an empty str `""` is a substring.
 
-From here, the actual command cases need to be distiguished with pattern matching:
+From here, the actual command cases need to be distinguished with pattern matching:
 
 - `RETRIEVE` has no whitespace and no payload
 - `PUBLISH <payload>` has always whitespace and an optional payload
@@ -59,7 +59,7 @@ From here, the actual command cases need to be distiguished with pattern matchin
 
 Missing, wrongly placed and more than one `\n` are errors that occur independent of other errors so it makes sense to handle these cases first. Split the incoming message at the first appearing `\n` using `split_once()`. This operation yields `Some((&str, &str))` if at least one `\n` is present, and `None` if 0 are present. If the `\n` is **not** the last item in the message, the second `&str` in `Some((&str, &str))` is not `""`.
 
-Tip: Introduce a generic variant `Command::Command` that temporarily stands for a valid command. 
+Tip: Introduce a generic variant `Command::Command` that temporarily stands for a valid command.
 
 Handle the two cases with match, check if the second part is `""`. Return `Err(Error::TrailingData)` or for wrongly placed `\n`, `Err(Error::IncompleteMessage)` for absent `\n` and `Ok(Command::Command)` if the `\n` is placed correct.
 

--- a/exercise-book/src/urls-match-result.md
+++ b/exercise-book/src/urls-match-result.md
@@ -40,7 +40,7 @@ x is the number of the step.
 2. Take the code from Step 1 and instead of using a `match`, propagate the Error
    with `?` out of `fn main()`. Note that your `main` function will now need to
    return something when it reaches the end.
-  
+
 3. Take the code from Step 2, and split the `String` into lines using the
    [`lines()`](https://doc.rust-lang.org/std/primitive.str.html#method.lines)
    method. Use this to count how many lines there are.
@@ -55,7 +55,7 @@ x is the number of the step.
    [Url](https://docs.rs/url/2.1.1/url/struct.Url.html), which is from the
    [`url` crate]. Use this function to convert each line and use the returned
    value to print either `Is a URL: <url>` or `Not a URL`.
-   
+
    The [`url` crate] has already been added as a dependency so you can just use
    `url::Url::parse`
 
@@ -125,14 +125,14 @@ enum Season {
 }
 
 fn which_season_is_now(season: Season) -> String {
-    
+
     let return_value = match season {
         Season::Spring => String::from("It's spring!"),
         Season::Summer => String::from("It's summer!."),
         Season::Fall => String::from("It's Fall!"),
         Season::Winter => String::from("Brrr. It's Winter."),
     };
-    
+
     return_value
 }
 ```
@@ -232,11 +232,11 @@ wrong value to see what happens if there is an error.
 
 ✅ Take a look at the documentation of
 [std::lines](https://doc.rust-lang.org/std/primitive.str.html#method.lines). It
-returns a `struct Lines` which is an iterator. 
+returns a `struct Lines` which is an iterator.
 
 ✅ Add a block like `for line in my_contents.lines() { }`
 
-✅ Declare a mutable integer, initialised to zero. Increment that integer inside
+✅ Declare a mutable integer, initialized to zero. Increment that integer inside
 the for loop.
 
 ✅ Print the number of lines the file contains.


### PR DESCRIPTION
- fix most of typos
- enforce Oxford spelling (`-ize` and `-ization`)
- did not touch British spelling
