### PR TITLE
Update github actions to node.js 20 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install tools
         uses: taiki-e/install-action@v2
@@ -32,7 +32,7 @@ jobs:
           ./build.sh "./rust-exercises-${{ env.slug }}"
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{success()}}
         with:
           name: Artifacts


### PR DESCRIPTION
Older ones used node.js 16 which is not supported. This causes a warning annotation on the Job Summary page.