### PR TITLE
Removed use of static mut.

### DIFF
--- a/nrf52-code/boards/dk-solution/Cargo.toml
+++ b/nrf52-code/boards/dk-solution/Cargo.toml
@@ -12,6 +12,7 @@ cortex-m-semihosting = "0.5.0"
 defmt = "0.3.5"
 defmt-rtt = "0.4"
 embedded-hal = "0.2.7"
+grounded = { version = "0.2.0", features = ["cas"] }
 hal = { package = "nrf52840-hal", version = "0.16.0" }
 
 [features]

--- a/nrf52-code/boards/dk-solution/src/lib.rs
+++ b/nrf52-code/boards/dk-solution/src/lib.rs
@@ -15,7 +15,11 @@ use core::{
 use cortex_m::peripheral::NVIC;
 use cortex_m_semihosting::debug;
 use embedded_hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
-#[cfg(feature = "radio")]
+#[cfg(any(feature = "advanced"))]
+use grounded::uninit::GroundedArrayCell;
+#[cfg(any(feature = "radio"))]
+use grounded::uninit::GroundedCell;
+#[cfg(any(feature = "radio"))]
 pub use hal::ieee802154;
 pub use hal::pac::{interrupt, Interrupt, NVIC_PRIO_BITS, RTC0};
 use hal::{
@@ -39,6 +43,14 @@ mod errata;
 pub mod peripheral;
 #[cfg(feature = "advanced")]
 pub mod usbd;
+
+#[cfg(feature = "radio")]
+struct ClockSyncWrapper<H, L, LSTAT> {
+    clocks: Clocks<H, L, LSTAT>,
+}
+
+#[cfg(feature = "radio")]
+unsafe impl<H, L, LSTAT> Sync for ClockSyncWrapper<H, L, LSTAT> {}
 
 /// Components on the board
 pub struct Board {
@@ -210,6 +222,7 @@ impl ops::DerefMut for Timer {
 }
 
 /// The ways that initialisation can fail
+#[derive(Debug, Copy, Clone, defmt::Format)]
 pub enum Error {
     /// You tried to initialise the board twice
     DoubleInit = 1,
@@ -224,12 +237,16 @@ pub fn init() -> Result<Board, Error> {
     };
     // NOTE(static mut) this branch runs at most once
     #[cfg(feature = "advanced")]
-    static mut EP0IN_BUF: [u8; 64] = [0; 64];
+    static EP0IN_BUF: GroundedArrayCell<u8, 64> = GroundedArrayCell::const_init();
     #[cfg(feature = "radio")]
-    static mut CLOCKS: Option<
-        Clocks<clocks::ExternalOscillator, clocks::ExternalOscillator, clocks::LfOscStarted>,
-    > = None;
-
+    // We need the wrapper to make this type Sync, as it contains raw pointers
+    static CLOCKS: GroundedCell<
+        ClockSyncWrapper<
+            clocks::ExternalOscillator,
+            clocks::ExternalOscillator,
+            clocks::LfOscStarted,
+        >,
+    > = GroundedCell::uninit();
     defmt::debug!("Initializing the board");
 
     let clocks = Clocks::new(periph.CLOCK);
@@ -239,7 +256,14 @@ pub fn init() -> Result<Board, Error> {
     let _clocks = clocks.enable_ext_hfosc();
     // extend lifetime to `'static`
     #[cfg(feature = "radio")]
-    let clocks = unsafe { CLOCKS.get_or_insert(_clocks) };
+    let clocks = unsafe {
+        let clocks_ptr = CLOCKS.get();
+        clocks_ptr.write(ClockSyncWrapper { clocks: _clocks });
+        // Now it's initialised, we can take a static reference to the clocks
+        // object it contains.
+        let clock_wrapper: &'static ClockSyncWrapper<_, _, _> = &*clocks_ptr;
+        &clock_wrapper.clocks
+    };
 
     defmt::debug!("Clocks configured");
 
@@ -311,7 +335,7 @@ pub fn init() -> Result<Board, Error> {
         #[cfg(feature = "advanced")]
         power: periph.POWER,
         #[cfg(feature = "advanced")]
-        ep0in: unsafe { Ep0In::new(&mut EP0IN_BUF) },
+        ep0in: unsafe { Ep0In::new(&EP0IN_BUF) },
     })
 }
 

--- a/nrf52-code/boards/dk/Cargo.toml
+++ b/nrf52-code/boards/dk/Cargo.toml
@@ -12,6 +12,7 @@ cortex-m-semihosting = "0.5.0"
 defmt = "0.3.5"
 defmt-rtt = "0.4"
 embedded-hal = "0.2.7"
+grounded = { version = "0.2.0", features = ["cas"] }
 hal = { package = "nrf52840-hal", version = "0.16.0" }
 
 [features]

--- a/nrf52-code/hal-app/Cargo.lock
+++ b/nrf52-code/hal-app/Cargo.lock
@@ -159,8 +159,8 @@ dependencies = [
  "defmt",
  "defmt-rtt",
  "embedded-hal",
+ "grounded",
  "nrf52840-hal",
- "panic-probe",
 ]
 
 [[package]]
@@ -198,6 +198,15 @@ dependencies = [
  "bytemuck",
  "half",
  "typenum",
+]
+
+[[package]]
+name = "grounded"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917d82402c7eb9755fdd87d52117701dae9e413a6abb309fac2a13af693b6080"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -320,6 +329,12 @@ dependencies = [
  "cortex-m",
  "defmt",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "proc-macro-error"

--- a/nrf52-code/radio-app/Cargo.lock
+++ b/nrf52-code/radio-app/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "defmt",
  "defmt-rtt",
  "embedded-hal",
+ "grounded",
  "nrf52840-hal",
 ]
 
@@ -197,6 +198,15 @@ dependencies = [
  "bytemuck",
  "half",
  "typenum",
+]
+
+[[package]]
+name = "grounded"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917d82402c7eb9755fdd87d52117701dae9e413a6abb309fac2a13af693b6080"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -306,6 +316,12 @@ dependencies = [
  "cortex-m",
  "defmt",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "proc-macro-error"

--- a/nrf52-code/usb-app-solutions/Cargo.lock
+++ b/nrf52-code/usb-app-solutions/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "defmt",
  "defmt-rtt",
  "embedded-hal",
+ "grounded",
  "nrf52840-hal",
 ]
 
@@ -250,6 +251,15 @@ dependencies = [
  "bytemuck",
  "half",
  "typenum",
+]
+
+[[package]]
+name = "grounded"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917d82402c7eb9755fdd87d52117701dae9e413a6abb309fac2a13af693b6080"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -389,6 +399,12 @@ dependencies = [
  "cortex-m",
  "defmt",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "proc-macro-error"

--- a/nrf52-code/usb-app/Cargo.lock
+++ b/nrf52-code/usb-app/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "defmt",
  "defmt-rtt",
  "embedded-hal",
+ "grounded",
  "nrf52840-hal",
 ]
 
@@ -250,6 +251,15 @@ dependencies = [
  "bytemuck",
  "half",
  "typenum",
+]
+
+[[package]]
+name = "grounded"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "917d82402c7eb9755fdd87d52117701dae9e413a6abb309fac2a13af693b6080"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -389,6 +399,12 @@ dependencies = [
  "cortex-m",
  "defmt",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
 name = "proc-macro-error"


### PR DESCRIPTION
Remove `static mut` values, our references to which were going to cause a warning in the next Rust release.

Uses the grounded crate, and a custom wrapper to make an !Sync type Sync.

Closes: #84 