### PR TITLE
QEMU UART example: typo fix

### DIFF
--- a/qemu-code/uart-driver/src/main.rs
+++ b/qemu-code/uart-driver/src/main.rs
@@ -15,8 +15,8 @@ use uart_exercise::PERIPHERAL_CLOCK;
 
 /// The entry-point to the Rust application.
 ///
-/// It is called by the start-up code in [`boot.S`](./boot.S) and thus exported
-/// as a C-compatible symbol.
+/// It is called by the start-up assembly code in [`lib.rs`](./lib.rs) and thus
+/// exported as a C-compatible symbol.
 #[no_mangle]
 pub extern "C" fn kmain() {
     if let Err(e) = main() {


### PR DESCRIPTION
I had moved the start-up code but still pointed to the old location.