### PR TITLE
Allow our use of cfg(TODO).

### DIFF
--- a/nrf52-code/usb-lib-solutions/get-descriptor-config/build.rs
+++ b/nrf52-code/usb-lib-solutions/get-descriptor-config/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(TODO)");
+}

--- a/nrf52-code/usb-lib-solutions/get-device/build.rs
+++ b/nrf52-code/usb-lib-solutions/get-device/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(TODO)");
+}

--- a/nrf52-code/usb-lib-solutions/set-config/build.rs
+++ b/nrf52-code/usb-lib-solutions/set-config/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(TODO)");
+}

--- a/nrf52-code/usb-lib/build.rs
+++ b/nrf52-code/usb-lib/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(TODO)");
+}


### PR DESCRIPTION
Rust got much fussier about these in 1.80. See https://blog.rust-lang.org/2024/05/06/check-cfg.html.

Closes: #110 