### PR TITLE
Minor edits

### DIFF
--- a/exercise-book/src/simple-db-knowledge.md
+++ b/exercise-book/src/simple-db-knowledge.md
@@ -2,7 +2,7 @@
 
 This section explains concepts necessary to solve the simpleDB exercise.
 
-In general, we also recommend to use the Rust documentation to figure out things you are missing to familiarize yourself with it. If you ever feel completely stuck or that you haven’t understood something, please hail the trainers quickly.
+We also recommend using the official Rust documentation to figure out unfamiliar concepts. If you ever feel completely stuck, or if you haven’t understood something specific, please hail the trainers quickly.
 
 ## Derives
 

--- a/exercise-book/src/simple-db-solution.md
+++ b/exercise-book/src/simple-db-solution.md
@@ -16,7 +16,7 @@ cargo test
 
 </details>
 
-## Step 2: Appropriate data structures
+## Step 2: Define appropriate data structures
 
 Define two enums, one is called `Command` and one is called `Error`. `Command` has 2 variants for the two possible commands. `Publish` carries data (the message), `Retrieve` does not. `Error` is just a list of error *kinds*. Use `#[derive(Eq,PartialEq,Debug)]` for both `enums`.
 

--- a/exercise-book/src/simple-db.md
+++ b/exercise-book/src/simple-db.md
@@ -62,7 +62,7 @@ With the additional properties:
 4. Empty payloads are allowed. In this case, the command is
     `PUBLISH \n`.
 
-Errors in the form or properties of the messages are
+Issues with the format (or other properties) of the messages are
 handled with the following error codes:
 
 - `UnexpectedNewline` (a newline not at the end of the line)

--- a/exercise-book/src/simple-db.md
+++ b/exercise-book/src/simple-db.md
@@ -59,7 +59,7 @@ With the additional properties:
 
 3. A newline other than at the end of the command is an error.
 
-4. Empty payloads are allowed. In this case, the command is
+4. An empty payload is allowed. The command to publish an empty payload is
     `PUBLISH \n`.
 
 Issues with the format (or other properties) of the messages are

--- a/exercise-book/src/simple-db.md
+++ b/exercise-book/src/simple-db.md
@@ -2,7 +2,7 @@
 
 In this exercise, we will implement a toy protocol parser for a simple protocol for databank queries. We call it simpleDB. The protocol has two commands, one of them can be sent with a payload of additional data. Your parser parses the incoming data strings, makes sure the commands are formatted correctly and returns errors for the different ways the formatting can go wrong.
 
-## After completing this exercise you are able to
+## After completing this exercise you will be able to
 
 - write a simple Rust library from scratch
 
@@ -62,7 +62,7 @@ With the additional properties:
 4. Empty payloads are allowed. In this case, the command is
     `PUBLISH \n`.
 
-Violations against the form of the messages and the properties are
+Errors in the form or properties of the messages are
 handled with the following error codes:
 
 - `UnexpectedNewline` (a newline not at the end of the line)


### PR DESCRIPTION
- why do we split things into files here (only?)
- Is it worth talking about why we choose the order we do in the algothrithm in 4.x? 
- in L62 of `simple-db.m`: 

> 4. Empty payloads are allowed. In this case, the command is
    `PUBLISH \n`.

Does this mean if the payload is emppty the command is determined to be PUBLISH. Or does it mean that only PUBLISH can have an empty payload.
