### PR TITLE
Rename USB interrupt handler.

### DIFF
--- a/exercise-book/src/nrf52-usb-usb-events.md
+++ b/exercise-book/src/nrf52-usb-usb-events.md
@@ -4,7 +4,7 @@ The `USBD` peripheral on the nRF52840 contains a series of registers, called `EV
 
 ✅ Open the [`nrf52-code/usb-app/src/bin/usb-1.rs`][usb_1] file.
 
-In this starter code the `USBD` peripheral is initialized in `init` and a task, named `main`, is bound to the interrupt signal called `USBD`. This task will be called every time a new `USBD` event needs to be handled. The `main` task uses `usbd::next_event()` to check all the event registers; if any event is set (i.e. that event just occurred) then the function returns the event, represented by the `Event` enum, wrapped in the `Some` variant. This `Event` is then passed to the `on_event` function for further processing.
+In this starter code the `USBD` peripheral is initialized in `init` and a task, named `handle_usb_interrupt`, is bound to the interrupt signal called `USBD`. This task will be called every time a new `USBD` event needs to be handled. The `handle_usb_interrupt` task uses `usbd::next_event()` to check all the event registers; if any event is set (i.e. that event just occurred) then the function returns the event, represented by the `Event` enum, wrapped in the `Some` variant. This `Event` is then passed to the `on_event` function for further processing.
 
 ✅ Connect the USB cable to the port J3 then run the starter code.
 

--- a/nrf52-code/usb-app-solutions/src/bin/usb-1.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-1.rs
@@ -37,7 +37,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
 
         while let Some(event) = usbd::next_event(usbd) {

--- a/nrf52-code/usb-app-solutions/src/bin/usb-2.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-2.rs
@@ -35,7 +35,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
 
         while let Some(event) = usbd::next_event(usbd) {

--- a/nrf52-code/usb-app-solutions/src/bin/usb-3.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-3.rs
@@ -38,7 +38,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd, ep0in])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
         let ep0in = cx.local.ep0in;
 

--- a/nrf52-code/usb-app-solutions/src/bin/usb-4.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-4.rs
@@ -43,7 +43,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd, ep0in, state])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
         let ep0in = cx.local.ep0in;
         let state = cx.local.state;

--- a/nrf52-code/usb-app-solutions/src/bin/usb-5.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-5.rs
@@ -43,7 +43,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd, ep0in, state])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
         let ep0in = cx.local.ep0in;
         let state = cx.local.state;

--- a/nrf52-code/usb-app/src/bin/usb-1.rs
+++ b/nrf52-code/usb-app/src/bin/usb-1.rs
@@ -37,7 +37,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
 
         while let Some(event) = usbd::next_event(usbd) {

--- a/nrf52-code/usb-app/src/bin/usb-2.rs
+++ b/nrf52-code/usb-app/src/bin/usb-2.rs
@@ -35,7 +35,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
 
         while let Some(event) = usbd::next_event(usbd) {

--- a/nrf52-code/usb-app/src/bin/usb-3.rs
+++ b/nrf52-code/usb-app/src/bin/usb-3.rs
@@ -38,7 +38,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd, ep0in])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
         let ep0in = cx.local.ep0in;
 

--- a/nrf52-code/usb-app/src/bin/usb-4.rs
+++ b/nrf52-code/usb-app/src/bin/usb-4.rs
@@ -44,7 +44,7 @@ mod app {
     }
 
     #[task(binds = USBD, local = [usbd, ep0in, state])]
-    fn main(cx: main::Context) {
+    fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
         let usbd = cx.local.usbd;
         let ep0in = cx.local.ep0in;
         let state = cx.local.state;


### PR DESCRIPTION
The name 'main' is just confusing.

Closes #132 