### PR TITLE
add  after defaulting to beta/nightly

### DIFF
--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Install targets
         run: |
           rustup target add thumbv7em-none-eabihf
-          rustup component add rust-src
-          rustup component add rustfmt
 
       - name: Update and set default Rust
         run: |
           rustup update ${{ matrix.rust-channel }}
           rustup default ${{ matrix.rust-channel }}
+          rustup component add rust-src
+          rustup component add rustfmt
 
       - name: Find slug name
         run: |


### PR DESCRIPTION
Given the error reported in the logs (https://github.com/ferrous-systems/rust-exercises/actions/runs/12858393639/job/35847429519), I'm adding `rustfmt` ltaer in the build process, so that it doesn't only pull it in for stable.

Should close #162.