### PR TITLE
bump proc-macro2 dep to pass nightly tests and add fail-fast-false

### DIFF
--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   weekly-canary-build:
     strategy:
+        fail-fast: false
         matrix:
             rust-channel: [stable, beta, nightly]
     runs-on: ubuntu-20.04

--- a/exercise-solutions/connected-mailbox/Cargo.lock
+++ b/exercise-solutions/connected-mailbox/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/exercise-solutions/multi-threaded-mailbox/Cargo.lock
+++ b/exercise-solutions/multi-threaded-mailbox/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [

--- a/exercise-solutions/multi-threaded-mailbox/Cargo.lock
+++ b/exercise-solutions/multi-threaded-mailbox/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ec6d5fe0b140acb27c9a0444118cf55bfbb4e0b259739429abb4521dd67c16"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]


### PR DESCRIPTION
This PR involves 2 small changes:

1. It bumps the `proc-macro2` dependency to one that doesn't break on [nightly](https://github.com/jonasbb/serde_with/pull/609/files) (This was a well [documented break then](https://github.com/rust-lang/rust/issues/113152).)
2. It adds a `fail-fast: false` argument to the weekly canary to make it so if one stable/beta/nightly fails the other jobs still run.

Should fix #168 