### PR TITLE
update github actions to ubuntu-24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:

--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -10,7 +10,7 @@ jobs:
         fail-fast: false
         matrix:
             rust-channel: [stable, beta, nightly]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:


### PR DESCRIPTION
Our jobs will start [failing in a month](https://github.com/actions/runner-images/issues/11101) unless we update.

Let's try 24.04 to see if everything works, else go for 22.04.