### PR TITLE
add rust-cache to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
 
       - name: Install tools
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
This adds the `rust-cache` GitHub Action to the repo.

The reason why I want to add this as a small PR is that subsequent PRs made to the repo can modify said caching logic and we can thus see how efficient different batching strategies can be, but we need to setup the cache first.