### PR TITLE
Bump probe-rs version to 0.27.

### DIFF
--- a/exercise-book/src/nrf52-tools.md
+++ b/exercise-book/src/nrf52-tools.md
@@ -108,10 +108,10 @@ cargo install nrfdfu
 cargo install cyme
 ```
 
-Install `probe-rs` 0.24 pre-compiled binaries on Linux with:
+Install `probe-rs` 0.27 pre-compiled binaries on Linux with:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.27.0/probe-rs-tools-installer.sh | sh
 ```
 
 ## Windows
@@ -182,10 +182,10 @@ cargo install nrfdfu
 cargo install cyme
 ```
 
-Install `probe-rs` 0.24 pre-compiled binaries on Windows with:
+Install `probe-rs` 0.27 pre-compiled binaries on Windows with:
 
 ```bash
-powershell -c "irm https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-installer.ps1 | iex"
+powershell -c "irm https://github.com/probe-rs/probe-rs/releases/download/v0.27.0/probe-rs-tools-installer.ps1 | iex"
 ```
 
 ## macOS
@@ -229,10 +229,10 @@ cargo install nrfdfu
 cargo install cyme
 ```
 
-Install `probe-rs` 0.24 pre-compiled binaries on macOS with:
+Install `probe-rs` 0.27 pre-compiled binaries on macOS with:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.27.0/probe-rs-tools-installer.sh | sh
 ```
 
 ---

--- a/nrf52-code/hal-app/.cargo/config.toml
+++ b/nrf52-code/hal-app/.cargo/config.toml
@@ -4,13 +4,10 @@
 runner = [
   "probe-rs",
   "run",
-  "--chip",
-  "nRF52840_xxAA",
+  "--chip=nRF52840_xxAA",
   "--allow-erase-all",
-  "--log-format",
-  "{[{L}]%bold} {s} {({c:bold} {fff}:{l:1})%dimmed}"
+  "--log-format=oneline"
 ]
-# Or use "{t} {[{L}]%bold} {s} {({c:bold} {fff}:{l:1})%dimmed}" to enable timestamps
 
 rustflags = [
   "-C", "link-arg=-Tlink.x", # use the cortex-m-rt linker script

--- a/nrf52-code/radio-app/.cargo/config.toml
+++ b/nrf52-code/radio-app/.cargo/config.toml
@@ -4,13 +4,10 @@
 runner = [
   "probe-rs",
   "run",
-  "--chip",
-  "nRF52840_xxAA",
+  "--chip=nRF52840_xxAA",
   "--allow-erase-all",
-  "--log-format",
-  "{[{L}]%bold} {s} {({c:bold} {fff}:{l:1})%dimmed}"
+  "--log-format=oneline"
 ]
-# Or use "{t} {[{L}]%bold} {s} {({c:bold} {fff}:{l:1})%dimmed}" to enable timestamps
 
 rustflags = [
   "-C", "link-arg=-Tlink.x", # use the cortex-m-rt linker script

--- a/nrf52-code/usb-app-solutions/.cargo/config.toml
+++ b/nrf52-code/usb-app-solutions/.cargo/config.toml
@@ -4,13 +4,10 @@
 runner = [
   "probe-rs",
   "run",
-  "--chip",
-  "nRF52840_xxAA",
+  "--chip=nRF52840_xxAA",
   "--allow-erase-all",
-  "--log-format",
-  "{[{L}]%bold} {s} {({c:bold} {fff}:{l:1})%dimmed}"
+  "--log-format=oneline"
 ]
-# Or use "{t} {[{L}]%bold} {s} {({c:bold} {fff}:{l:1})%dimmed}" to enable timestamps
 
 rustflags = [
   "-C", "link-arg=-Tlink.x", # use the cortex-m-rt linker script

--- a/nrf52-code/usb-app/.cargo/config.toml
+++ b/nrf52-code/usb-app/.cargo/config.toml
@@ -4,13 +4,10 @@
 runner = [
   "probe-rs",
   "run",
-  "--chip",
-  "nRF52840_xxAA",
+  "--chip=nRF52840_xxAA",
   "--allow-erase-all",
-  "--log-format",
-  "{[{L}]%bold} {s} {({c:bold} {fff}:{l:1})%dimmed}"
+  "--log-format=oneline"
 ]
-# Or use "{t} {[{L}]%bold} {s} {({c:bold} {fff}:{l:1})%dimmed}" to enable timestamps
 
 linker = "flip-link" # adds stack overflow protection
 rustflags = [


### PR DESCRIPTION
Allows us to use the 'oneline' log format from