### PR TITLE
Actually, homebrew does ship EDK2 with qemu-system-aarch64

### DIFF
--- a/exercise-book/src/building-linux-kernel-driver.md
+++ b/exercise-book/src/building-linux-kernel-driver.md
@@ -29,18 +29,15 @@ wget https://cdimage.debian.org/images/cloud/bookworm/20250316-2053/debian-12-no
 
 ## Task 1a - Fetch the BIOS (AArch64 only)
 
-If you are going to use AArch64, you'll need a UEFI boot-loader because QEMU
-doesn't come with one (or at least, the QEMU in homebrew that I used didn't come
-with one).
+If you are going to use AArch64, you'll need a UEFI boot-loader. On macOS,
+homebrew installs a copy of [EDK2](https://github.com/tianocore/edk2), which is
+fine for our use-case. On my machine it was installed into
+`/opt/homebrew/Cellar/qemu/9.2.2/share/qemu/edk2-aarch64-code.fd`. You'll need
+to have a look in your QEMU installation directory to find where your copy is.
+Once you have found it, copy it to `./QEMU_EFI.fd`, which is what the following
+`qemu-system-aarch64` command lines expect.
 
-Download it from <https://gist.githubusercontent.com/theboreddev/5f79f86a0f163e4a1f9df919da5eea20/raw/f546faea68f4149c06cca88fa67ace07a3758268/QEMU_EFI-a096471-edk2-stable202011.tar.gz> and unpack it.
-
-```bash
-wget https://gist.githubusercontent.com/theboreddev/5f79f86a0f163e4a1f9df919da5eea20/raw/f546faea68f4149c06cca88fa67ace07a3758268/QEMU_EFI-a096471-edk2-stable202011.tar.gz
-tar xvf QEMU_EFI-a096471-edk2-stable202011.tar.gz
-```
-
-(Windows users, use your favourite tools for this)
+When emulating x86-64, QEMU uses a copy of SeaBIOS automatically.
 
 ## Task 2 - Resize the disk image
 


### PR DESCRIPTION
Tell people where to find EDK2 in their QEMU install directory, rather than downloading random blobs from a Github gist.