### PR TITLE
Invoke proper caching on CI

### DIFF
--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -37,19 +37,25 @@ jobs:
       # selecting a toolchain either by action or manual `rustup` calls should happen
       # before the plugin, as the cache uses the current rustc version as its cache key
       - run: rustup toolchain install stable --profile minimal
-      - uses: Swatinem/rust-cache@v2
 
-      - name: Install targets
+      - name: Load functions
         run: |
           . build_fns.sh
-          mdbook_test_build exercise-book
+          cd exercise-book
+
+        # For the cache to be keyed properly, we need to `cd` into a directory that can invoke `cargo` commands.
+        # Thus above `cd exercise-book` *has* to happen before invoking the `Swatinem/rust-cache@v2` action.
+      - uses: Swatinem/rust-cache@v2
+      - name: Load cache
+        run: |
+          mdbook_test_build
 
       # Uploading an artifact is how we can share data between different jobs
       - name: Upload mdbook artifacts
         uses: actions/upload-artifact@v4
         with:
           name: mdbook-dir
-          path: exercise-book/book/
+          path: book/
           if-no-files-found: error
   
   test_exercise_solutions_and_examples:
@@ -57,12 +63,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
-      - uses: Swatinem/rust-cache@v2
 
       - name: Test exercise-solutions and examples
         run: |
           . build_fns.sh
-          test_examples exercise-solutions
+          cd exercise-solutions
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Load cache
+        run: |
+          test_examples
   
   test_exercise_solutions_standalone_crates:
     runs-on: ubuntu-24.04
@@ -73,12 +83,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
-      - uses: Swatinem/rust-cache@v2
     
       - name: Test exercise-solutions standalone crates
         run: |
           . build_fns.sh
-          test ${{matrix.crates}}
+          cd ${{matrix.crates}}
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Load cache
+        run: |
+          test
 
   build_qemu_core:
     runs-on: ubuntu-24.04
@@ -90,7 +104,12 @@ jobs:
       - name: Build qemu-code/uart-driver
         run: |
           . build_fns.sh
-          build_core qemu-code/uart-driver
+          cd qemu-code/uart-driver
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Load cache
+        run: |
+          build_qemu
 
   build_nrf52_usb_crates:
     runs-on: ubuntu-24.04
@@ -116,7 +135,12 @@ jobs:
       - name: build-only nrf52 crates
         run: |
           . build_fns.sh
-          build_thumbv7em ${{matrix.crates}}
+          cd ${{matrix.crates}}
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Load cache
+        run: |
+          build_thumbv7em
 
   # This job is different from the one above because we cannot make individual steps conditional,
   # but we can define a different `matrix` of files that we have to upload
@@ -133,19 +157,23 @@ jobs:
 
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --target thumbv7em-none-eabihf
-      - uses: Swatinem/rust-cache@v2
         
       - name: build-only nrf52 crates
         run: |
           . build_fns.sh
-          build_thumbv7em nrf52-code/${{matrix.crates}}
+          cd nrf52-code/${{matrix.crates}}
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Load cache
+        run: |
+          build_thumbv7em
 
       # We also upload the built binaries in the puzzle-fw and loopback-fw cases
       - name: Upload ${{matrix.crates}} artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.crates}}
-          path: nrf52-code/${{matrix.crates}}/target/thumbv7em-none-eabihf/release/
+          path: ${{matrix.crates}}/target/thumbv7em-none-eabihf/release/
           if-no-files-found: error
   
   build_and_test_nrf52_crates:
@@ -164,12 +192,16 @@ jobs:
 
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --target thumbv7em-none-eabihf
-      - uses: Swatinem/rust-cache@v2
         
       - name: build-and-test nrf52 crates
         run: |
           . build_fns.sh
-          build_test_thumbv7em ${{matrix.crates}}
+          cd ${{matrix.crates}}
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Load cache
+        run: |
+          build_test_thumbv7em
 
   check_templates:
     runs-on: ubuntu-24.04
@@ -180,7 +212,12 @@ jobs:
       - name: Check exercise-templates
         run: |
           . build_fns.sh
-          check_templates exercise-templates 
+          cd exercise-templates
+
+      - uses: Swatinem/rust-cache@v2
+      - name: Load cache
+        run: |
+          check_templates
 
   check_fmt:
     runs-on: ubuntu-24.04

--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -1,6 +1,6 @@
 # This is a workflow file to run, build, and test all crates used as part of `rust-exercises`.
 # It is cached with Swatinem/rust-cache@v2 and setup so that no jobs depend on any other jobs, 
-# EXCEPT for the last `deploy` job, which marks all other jobs in the `needs:` field as a dependency to fire.
+# EXCEPT for the last `deploy` job, which pulls in artifacts-producing jobs in the `needs:` field.
 # The brunt of the work is defined in `build_fns.sh` where the actual build/testing logic is defined.
 
 name: rust-exercises
@@ -20,10 +20,31 @@ on:
     branches:
       - main
 
-# * All jobs defined here run independently of each other.
+# * All jobs defined here run independently of each other EXCEPT for `deploy`.
 # * Jobs that have a `matrix` field will setup up a job per entry in said `matrix`.
-# If you add *ANY* jobs, make sure to add them to the `needs:` field of the `deploy` job, since that
-# ensures `deploy` will run last.
+# If you add any jobs that produce artifacts, make sure to add them to the `needs:` field of the `deploy` job, since that
+# ensures `deploy` will run last and can pull said artifacts
+# 
+# ========== TEMPLATE ===========
+# my_cool_new_job:
+# runs-on: ubuntu-24.04
+# steps:
+# - uses: actions/checkout@v4                     # This is what downloads a fresh clone of the repo and cd's into it
+# - name: Install tools
+#  uses: taiki-e/install-action@v2                # For adding arbitrary binaries as tools
+#  with:
+#    tool: name_of_binary_tool@v1.0
+# - uses: Swatinem/rust-cache@v2
+#   with:
+#     workspaces: dir_where_I_want_results_cached # This job will look up this specific cached dir
+# - name: Build foo
+#  run: | 
+#    . ${{github.workspace}}/build_fns.sh
+#    cd interesting_directory
+#    command_defined_in_build_fns.sh
+# =========== END TEMPLATE ========
+#
+# And then you'd add `my_cool_new_job` to the `needs` field of `deploy`.
 jobs:
   test_and_build_mdbook:
     runs-on: ubuntu-24.04
@@ -38,16 +59,14 @@ jobs:
       # before the plugin, as the cache uses the current rustc version as its cache key
       - run: rustup toolchain install stable --profile minimal
 
-      - name: Load functions
-        run: |
-          . build_fns.sh
-          cd exercise-book
-
-        # For the cache to be keyed properly, we need to `cd` into a directory that can invoke `cargo` commands.
-        # Thus above `cd exercise-book` *has* to happen before invoking the `Swatinem/rust-cache@v2` action.
+        # For the cache to be keyed properly, we need to declare the workspace and then `cd` into it.
       - uses: Swatinem/rust-cache@v2
-      - name: Load cache
+        with:
+          workspaces: exercise-book
+      - name: Build mdbook, Test mdbook, Load cache
         run: |
+          . ${{github.workspace}}/build_fns.sh
+          cd exercise-book
           mdbook_test_build
 
       # Uploading an artifact is how we can share data between different jobs
@@ -55,23 +74,23 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: mdbook-dir
-          path: book/
+          path: exercise-book/book/
           if-no-files-found: error
   
   test_exercise_solutions_and_examples:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install stable --profile minimal
-
-      - name: Test exercise-solutions and examples
-        run: |
-          . build_fns.sh
-          cd exercise-solutions
+      - run: |
+          rustup toolchain install stable --profile minimal
 
       - uses: Swatinem/rust-cache@v2
-      - name: Load cache
+        with:
+          workspaces: exercise-solutions
+      - name: Test exercise-solutions and examples, with cache
         run: |
+          . ${{github.workspace}}/build_fns.sh
+          cd exercise-solutions
           test_examples
   
   test_exercise_solutions_standalone_crates:
@@ -84,32 +103,29 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
     
-      - name: Test exercise-solutions standalone crates
-        run: |
-          . build_fns.sh
-          cd ${{matrix.crates}}
-
       - uses: Swatinem/rust-cache@v2
-      - name: Load cache
+        with:
+          workspaces: ${{matrix.crates}}
+      - name: Test exercise-solutions standalone crates, Load cache
         run: |
-          test
+          . ${{github.workspace}}/build_fns.sh
+          cd ${{matrix.crates}}
+          test_standalone
 
   build_qemu_core:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rust-src
-      - uses: Swatinem/rust-cache@v2
 
-      - name: Build qemu-code/uart-driver
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: qemu-code/uart-driver
+      - name: Build-qemu-code/uart-driver, load cache
         run: |
-          . build_fns.sh
           cd qemu-code/uart-driver
-
-      - uses: Swatinem/rust-cache@v2
-      - name: Load cache
-        run: |
-          build_qemu
+          . ../../build_fns.sh
+          build_qemu_core
 
   build_nrf52_usb_crates:
     runs-on: ubuntu-24.04
@@ -131,15 +147,13 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --target thumbv7em-none-eabihf
       - uses: Swatinem/rust-cache@v2
-        
-      - name: build-only nrf52 crates
-        run: |
-          . build_fns.sh
-          cd ${{matrix.crates}}
+        with:
+          workspaces: ${{matrix.crates}}
 
-      - uses: Swatinem/rust-cache@v2
-      - name: Load cache
+      - name: build-nrf52 usb crates, Load cache
         run: |
+          . ${{github.workspace}}/build_fns.sh
+          cd ${{matrix.crates}}
           build_thumbv7em
 
   # This job is different from the one above because we cannot make individual steps conditional,
@@ -157,15 +171,14 @@ jobs:
 
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --target thumbv7em-none-eabihf
-        
-      - name: build-only nrf52 crates
-        run: |
-          . build_fns.sh
-          cd nrf52-code/${{matrix.crates}}
 
       - uses: Swatinem/rust-cache@v2
-      - name: Load cache
+        with:
+          workspaces: nrf52-code/${{matrix.crates}}
+      - name: build-only-nrf52 crates, load cache
         run: |
+          . ${{github.workspace}}/build_fns.sh
+          cd nrf52-code/${{matrix.crates}}
           build_thumbv7em
 
       # We also upload the built binaries in the puzzle-fw and loopback-fw cases
@@ -173,7 +186,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.crates}}
-          path: ${{matrix.crates}}/target/thumbv7em-none-eabihf/release/
+          path: nrf52-code/${{matrix.crates}}/target/thumbv7em-none-eabihf/release/${{matrix.crates}}
           if-no-files-found: error
   
   build_and_test_nrf52_crates:
@@ -192,15 +205,14 @@ jobs:
 
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --target thumbv7em-none-eabihf
-        
-      - name: build-and-test nrf52 crates
-        run: |
-          . build_fns.sh
-          cd ${{matrix.crates}}
 
       - uses: Swatinem/rust-cache@v2
-      - name: Load cache
+        with:
+          workspaces: ${{matrix.crates}}
+      - name: build-and-test nrf52 crates, load cache
         run: |
+          . ${{github.workspace}}/build_fns.sh
+          cd ${{matrix.crates}}
           build_test_thumbv7em
 
   check_templates:
@@ -208,15 +220,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal
-      - uses: Swatinem/rust-cache@v2
-      - name: Check exercise-templates
-        run: |
-          . build_fns.sh
-          cd exercise-templates
 
       - uses: Swatinem/rust-cache@v2
-      - name: Load cache
+        with:
+          workspaces: exercise-templates
+      - name: Check exercise-templates, Load cache
         run: |
+          . ${{github.workspace}}/build_fns.sh
+          cd exercise-templates
           check_templates
 
   check_fmt:
@@ -224,25 +235,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rustfmt
-      - uses: Swatinem/rust-cache@v2
       - name: Check fmt
         run: |
-          . build_fns.sh
+          . ${{github.workspace}}/build_fns.sh
           check_fmt
 
-  # This is the last job, and waits (`needs:`) on all the other jobs before firing.
+  # This is the last job, and waits (`needs:`) only on those that pass artifacts to it.
   # It the necessary resulting builds as artifacts, zips them, and uploads with a tag if necessary.
   deploy:
      runs-on: ubuntu-24.04
-     needs: [test_and_build_mdbook,
-             test_exercise_solutions_and_examples,
-             test_exercise_solutions_standalone_crates,
-             build_qemu_core,
-             build_nrf52_usb_crates,
-             build_nrf52_usb_crates_and_upload_fw,
-             build_and_test_nrf52_crates,
-             check_templates,
-             check_fmt]
+     # Notice that because our repo expects all checks to pass, we don't need to include every other job
+     # as a dependency of the `deploy` job.
+     needs: [test_and_build_mdbook, build_nrf52_usb_crates_and_upload_fw]
 
      steps:
        - uses: actions/checkout@v4
@@ -277,8 +281,8 @@ jobs:
          env: # Or as an environment variable
            HIDDEN_MESSAGE: ${{ secrets.HIDDEN_MESSAGE }}
          run: |
-           . build_fns.sh
-           zip_output "./rust-exercises-${{ env.slug }}"
+          . ${{github.workspace}}/build_fns.sh
+          zip_output "./rust-exercises-${{ env.slug }}"
 
        - name: Upload Artifacts
          uses: actions/upload-artifact@v4

--- a/build_fns.sh
+++ b/build_fns.sh
@@ -7,7 +7,7 @@
 #
 # This script will define functions for testing this repo.
 #
-#set -euo pipefail
+set -euo pipefail
 
 # Build and test the solutions
 # exercise-solutions
@@ -19,13 +19,13 @@ function test_examples() {
 
 # exercise-solutions/connected-mailbox
 # exercise-solutions/multi-threaded-mailbox
-function test() {
+function test_standalone() {
 	cargo test --locked
 	return 0
 }
 
 # qemu-code/uart-driver
-function build_qemu() {
+function build_qemu_core() {
 	RUSTC_BOOTSTRAP=1 cargo build -Zbuild-std=core --locked
 	return 0
 }
@@ -64,7 +64,7 @@ function mdbook_test_build() {
 	mdbook test
 	mdbook build
 	return 0
-}	
+}
 
 function zip_output() {
 	OUTPUT_NAME=${1:-./output}
@@ -90,6 +90,7 @@ function zip_output() {
 	cp ./nrf52-code/loopback-fw/target/thumbv7em-none-eabihf/release/loopback-fw "${OUTPUT_NAME}/nrf52-code/boards/dongle-fw/loopback-fw"
 	find "${OUTPUT_NAME}" -name target -type d -print0 | xargs -0 rm -rf
 	zip -r "${OUTPUT_NAME}.zip" "${OUTPUT_NAME}"
+	return 0
 }
 
 

--- a/build_fns.sh
+++ b/build_fns.sh
@@ -12,7 +12,6 @@
 # Build and test the solutions
 # exercise-solutions
 function test_examples() {
-	cd "$1" || return 1
 	cargo test --locked
 	cargo test --examples --locked
 	return 0
@@ -21,14 +20,12 @@ function test_examples() {
 # exercise-solutions/connected-mailbox
 # exercise-solutions/multi-threaded-mailbox
 function test() {
-	cd "$1" || return 1
 	cargo test --locked
 	return 0
 }
 
 # qemu-code/uart-driver
-function build_core() {
-	cd "$1" || return 1
+function build_qemu() {
 	RUSTC_BOOTSTRAP=1 cargo build -Zbuild-std=core --locked
 	return 0
 }
@@ -43,7 +40,6 @@ function build_core() {
 # nrf52-code/puzzle-fw
 # nrf52-code/loopback-fw
 function build_thumbv7em() {
-	cd "$1" || return 1
 	cargo build --target=thumbv7em-none-eabihf --locked --release
 	return 0
 }
@@ -53,7 +49,6 @@ function build_thumbv7em() {
 # nrf52-code/usb-lib-solutions/get-device
 # nrf52-code/usb-lib-solutions/set-config
 function build_test_thumbv7em() {
-	cd "$1" || return 1
 	cargo build --target=thumbv7em-none-eabihf --locked --release
 	cargo test --locked
 	return 0
@@ -61,13 +56,11 @@ function build_test_thumbv7em() {
 
 # exercise-templates
 function check_templates() {
-	cd "$1" || return 1
 	cargo check --locked
 	return 0
 }
 
 function mdbook_test_build() {
-	cd "$1" || return 1
 	mdbook test
 	mdbook build
 	return 0


### PR DESCRIPTION
The previous structure of this workflow (.yml file) did not invoke the `Swatinem/rust-cache` with the appropriate workspace per job.

Let's leverage that for even more speedups 🏁 

Should fix #195 