### PR TITLE
Fix dk reboot

### DIFF
--- a/nrf52-code/boards/dk-solution/Cargo.lock
+++ b/nrf52-code/boards/dk-solution/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -109,9 +109,8 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "defmt"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834fbddebd69852b7742f3b1fdd9df277c8f36a028c03b7002f7f513bac65fe"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -119,9 +118,8 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0f20557738ff14dad3e698b57da89f04d708433024c6f931dde286051b94a"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -133,8 +131,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "thiserror",
 ]
@@ -142,8 +139,7 @@ dependencies = [
 [[package]]
 name = "defmt-rtt"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "critical-section",
  "defmt",
@@ -223,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -350,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -404,9 +400,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nrf52-code/boards/dk-solution/Cargo.toml
+++ b/nrf52-code/boards/dk-solution/Cargo.toml
@@ -9,8 +9,8 @@ version = "0.0.0"
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.5"
 cortex-m-semihosting = "0.5.0"
-defmt = "1"
-defmt-rtt = "1"
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }
+defmt-rtt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219" }
 embedded-hal = "1.0"
 grounded = { version = "0.2.0", features = ["cas"] }
 hal = { package = "nrf52840-hal", version = "0.18.0" }

--- a/nrf52-code/boards/dk/Cargo.lock
+++ b/nrf52-code/boards/dk/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -109,9 +109,8 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "defmt"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834fbddebd69852b7742f3b1fdd9df277c8f36a028c03b7002f7f513bac65fe"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -119,9 +118,8 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0f20557738ff14dad3e698b57da89f04d708433024c6f931dde286051b94a"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -133,8 +131,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "thiserror",
 ]
@@ -142,8 +139,7 @@ dependencies = [
 [[package]]
 name = "defmt-rtt"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "critical-section",
  "defmt",
@@ -223,9 +219,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7db2ff139bba50379da6aa0766b52fdcb62cb5b263009b09ed58ba604e14bbd1"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -350,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -404,9 +400,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nrf52-code/boards/dk/Cargo.toml
+++ b/nrf52-code/boards/dk/Cargo.toml
@@ -9,8 +9,8 @@ version = "0.0.0"
 cortex-m = { version = "0.7.7", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.5"
 cortex-m-semihosting = "0.5.0"
-defmt = "1"
-defmt-rtt = "1"
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }
+defmt-rtt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219" }
 embedded-hal = "1.0"
 grounded = { version = "0.2.0", features = ["cas"] }
 hal = { package = "nrf52840-hal", version = "0.18.0" }

--- a/nrf52-code/boards/dk/src/lib.rs
+++ b/nrf52-code/boards/dk/src/lib.rs
@@ -299,6 +299,12 @@ pub enum Error {
 ///
 /// This return an `Err`or if called more than once
 pub fn init() -> Result<Board, Error> {
+    // probe-rs puts us in blocking mode, so wait for blocking mode as a proxy
+    // for waiting for probe-rs to connect.
+    while !defmt_rtt::in_blocking_mode() {
+        core::hint::spin_loop();
+    }
+
     let Some(periph) = hal::pac::Peripherals::take() else {
         return Err(Error::DoubleInit);
     };

--- a/nrf52-code/hal-app/Cargo.lock
+++ b/nrf52-code/hal-app/Cargo.lock
@@ -109,9 +109,8 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "defmt"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834fbddebd69852b7742f3b1fdd9df277c8f36a028c03b7002f7f513bac65fe"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -119,9 +118,8 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0f20557738ff14dad3e698b57da89f04d708433024c6f931dde286051b94a"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -133,8 +131,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "thiserror",
 ]
@@ -142,8 +139,7 @@ dependencies = [
 [[package]]
 name = "defmt-rtt"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "critical-section",
  "defmt",

--- a/nrf52-code/hal-app/Cargo.toml
+++ b/nrf52-code/hal-app/Cargo.toml
@@ -11,8 +11,8 @@ cortex-m = {version = "0.7.7", features = ["critical-section-single-core"]}
 cortex-m-rt = "0.7.5"
 dk = { path = "../boards/dk", features = ["radio"] }
 heapless = "0.8"
-defmt = "1"
-defmt-rtt = "1"
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }
+defmt-rtt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219" }
 
 # optimise a little bit
 [profile.dev]

--- a/nrf52-code/radio-app/Cargo.lock
+++ b/nrf52-code/radio-app/Cargo.lock
@@ -109,9 +109,8 @@ checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "defmt"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834fbddebd69852b7742f3b1fdd9df277c8f36a028c03b7002f7f513bac65fe"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -119,9 +118,8 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0f20557738ff14dad3e698b57da89f04d708433024c6f931dde286051b94a"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -133,8 +131,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "thiserror",
 ]
@@ -142,8 +139,7 @@ dependencies = [
 [[package]]
 name = "defmt-rtt"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "critical-section",
  "defmt",

--- a/nrf52-code/radio-app/Cargo.toml
+++ b/nrf52-code/radio-app/Cargo.toml
@@ -11,8 +11,8 @@ cortex-m = {version = "0.7.7", features = ["critical-section-single-core"]}
 cortex-m-rt = "0.7.5"
 dk = { path = "../boards/dk", features = ["radio"] }
 heapless = "0.8"
-defmt = "1"
-defmt-rtt = "1"
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }
+defmt-rtt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219" }
 
 # optimise a little bit
 [profile.dev]

--- a/nrf52-code/usb-app-solutions/Cargo.lock
+++ b/nrf52-code/usb-app-solutions/Cargo.lock
@@ -138,14 +138,13 @@ version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
 dependencies = [
- "defmt 1.0.0",
+ "defmt 1.0.1",
 ]
 
 [[package]]
 name = "defmt"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834fbddebd69852b7742f3b1fdd9df277c8f36a028c03b7002f7f513bac65fe"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -153,9 +152,8 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0f20557738ff14dad3e698b57da89f04d708433024c6f931dde286051b94a"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -167,8 +165,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "thiserror",
 ]
@@ -176,11 +173,10 @@ dependencies = [
 [[package]]
 name = "defmt-rtt"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "critical-section",
- "defmt 1.0.0",
+ "defmt 1.0.1",
 ]
 
 [[package]]
@@ -190,7 +186,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",
- "defmt 1.0.0",
+ "defmt 1.0.1",
  "defmt-rtt",
  "embedded-hal 1.0.0",
  "grounded",
@@ -608,7 +604,7 @@ dependencies = [
  "consts",
  "cortex-m",
  "cortex-m-rt",
- "defmt 1.0.0",
+ "defmt 1.0.1",
  "defmt-rtt",
  "dk",
  "heapless 0.7.17",

--- a/nrf52-code/usb-app-solutions/Cargo.toml
+++ b/nrf52-code/usb-app-solutions/Cargo.toml
@@ -15,8 +15,8 @@ consts = { path = "../consts" }
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7.5"
 rtic = { version = "2", features = ["thumbv7-backend"] }
-defmt = "1"
-defmt-rtt = "1"
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }
+defmt-rtt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219" }
 dk = { path = "../boards/dk", features = ["advanced"] }
 usb = { path = "../usb-lib-solutions/complete" }
 usb2 = "0.0.1"
@@ -39,3 +39,5 @@ lto = "fat"
 opt-level = 3
 overflow-checks = false
 
+[patch.crates-io]
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }

--- a/nrf52-code/usb-app/Cargo.lock
+++ b/nrf52-code/usb-app/Cargo.lock
@@ -138,14 +138,13 @@ version = "0.3.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0963443817029b2024136fc4dd07a5107eb8f977eaf18fcd1fdeb11306b64ad"
 dependencies = [
- "defmt 1.0.0",
+ "defmt 1.0.1",
 ]
 
 [[package]]
 name = "defmt"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834fbddebd69852b7742f3b1fdd9df277c8f36a028c03b7002f7f513bac65fe"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -153,9 +152,8 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0f20557738ff14dad3e698b57da89f04d708433024c6f931dde286051b94a"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -167,8 +165,7 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "thiserror",
 ]
@@ -176,11 +173,10 @@ dependencies = [
 [[package]]
 name = "defmt-rtt"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2cac3b8a5644a9e02b75085ebad3b6deafdbdbdec04bb25086523828aa4dfd1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "critical-section",
- "defmt 1.0.0",
+ "defmt 1.0.1",
 ]
 
 [[package]]
@@ -190,7 +186,7 @@ dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-semihosting",
- "defmt 1.0.0",
+ "defmt 1.0.1",
  "defmt-rtt",
  "embedded-hal 1.0.0",
  "grounded",
@@ -601,7 +597,8 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 name = "usb"
 version = "0.0.0"
 dependencies = [
- "defmt 1.0.0",
+ "defmt 1.0.1",
+ "defmt-rtt",
 ]
 
 [[package]]
@@ -611,7 +608,7 @@ dependencies = [
  "consts",
  "cortex-m",
  "cortex-m-rt",
- "defmt 1.0.0",
+ "defmt 1.0.1",
  "defmt-rtt",
  "dk",
  "heapless 0.7.17",

--- a/nrf52-code/usb-app/Cargo.toml
+++ b/nrf52-code/usb-app/Cargo.toml
@@ -15,8 +15,8 @@ consts = { path = "../consts" }
 cortex-m = "0.7.7"
 cortex-m-rt = "0.7.5"
 rtic = { version = "2", features = ["thumbv7-backend"] }
-defmt = "1"
-defmt-rtt = "1"
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }
+defmt-rtt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219" }
 dk = { path = "../boards/dk", features = ["advanced"] }
 usb = { path = "../usb-lib" }
 usb2 = "0.0.1"
@@ -39,3 +39,5 @@ lto = "fat"
 opt-level = 3
 overflow-checks = false
 
+[patch.crates-io]
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }

--- a/nrf52-code/usb-app/src/bin/vec.rs
+++ b/nrf52-code/usb-app/src/bin/vec.rs
@@ -17,13 +17,13 @@ fn main() -> ! {
 
     // `heapless::Vec` exposes the same API surface as `std::Vec` but some of its methods return a
     // `Result` to indicate whether the operation failed due to the `heapless::Vec` being full
-    defmt::println!("start: {:?}", buffer);
+    defmt::println!("start: {:?}", &buffer[..]);
 
     buffer.push(0).expect("buffer full");
-    defmt::println!("after `push`: {:?}", buffer);
+    defmt::println!("after `push`: {:?}", &buffer[..]);
 
     buffer.extend_from_slice(&[1, 2, 3]).expect("buffer full");
-    defmt::println!("after `extend`: {:?}", &buffer);
+    defmt::println!("after `extend`: {:?}", &buffer[..]);
 
     // TODO try this operation
     // buffer.extend_from_slice(&[4, 5, 6, 7]).expect("buffer full");

--- a/nrf52-code/usb-lib/Cargo.lock
+++ b/nrf52-code/usb-lib/Cargo.lock
@@ -9,10 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "defmt"
-version = "1.0.0"
+name = "critical-section"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834fbddebd69852b7742f3b1fdd9df277c8f36a028c03b7002f7f513bac65fe"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "defmt"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "bitflags",
  "defmt-macros",
@@ -20,9 +25,8 @@ dependencies = [
 
 [[package]]
 name = "defmt-macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e0f20557738ff14dad3e698b57da89f04d708433024c6f931dde286051b94a"
+version = "1.0.1"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "defmt-parser",
  "proc-macro-error2",
@@ -34,10 +38,18 @@ dependencies = [
 [[package]]
 name = "defmt-parser"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "defmt-rtt"
+version = "1.0.0"
+source = "git+https://github.com/knurling-rs/defmt/?rev=177c219#177c2195072caa1759ebe92221f4a50204cce46c"
+dependencies = [
+ "critical-section",
+ "defmt",
 ]
 
 [[package]]
@@ -122,4 +134,5 @@ name = "usb"
 version = "0.0.0"
 dependencies = [
  "defmt",
+ "defmt-rtt",
 ]

--- a/nrf52-code/usb-lib/Cargo.toml
+++ b/nrf52-code/usb-lib/Cargo.toml
@@ -7,4 +7,5 @@ version = "0.0.0"
 description = "Library for parsing USB requests"
 
 [dependencies]
-defmt = "1"
+defmt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219", version = "1.0.1" }
+defmt-rtt = { git = "https://github.com/knurling-rs/defmt/", rev = "177c219" }


### PR DESCRIPTION
Stops the DK from rebooting in a loop once you hit `semihosting::exit`.

It does this by waiting for probe-rs to place the SEGGER RTT buffer into blocking mode. This means the code only runs when started from `probe-rs run` and not after rebooting (and disconnected from probe-rs).

Currently using a git rev of defmt-rtt. See https://github.com/knurling-rs/defmt/pull/968.