### PR TITLE
Limit dongle flash usage.

### DIFF
--- a/nrf52-code/boards/dongle/memory.x
+++ b/nrf52-code/boards/dongle/memory.x
@@ -1,6 +1,9 @@
 MEMORY
 {
-  /* Start after the bootloader */
-  FLASH : ORIGIN = 0x00001000, LENGTH = 1020K
+  /*
+   * Start after the bootloader stub, and stop before the bootloader proper
+   * at 0xE0000
+   */
+  FLASH : ORIGIN = 0x00001000, LENGTH = 0xE0000 - 0x1000
   RAM   : ORIGIN = 0x20000000, LENGTH = 256K
 }


### PR DESCRIPTION
We never got near the limit, but it's important we don't one day accidentally trash the bootloader top-half at 0x000E_0000.

Should have zero effect on the resulting binary at this time.