### PR TITLE
Fix-up USB workshop

### DIFF
--- a/exercise-book/src/nrf52-radio-dongle.md
+++ b/exercise-book/src/nrf52-radio-dongle.md
@@ -64,7 +64,7 @@ After the device has been programmed it will automatically reset and start runni
 ```console
 $ cyme
 (..)
-  2  16  0x1209 0x0309 Dongle Loopback          -                 12.0 Mb/s
+  2  16  0x1209 0x0002 Dongle Loopback          -                 12.0 Mb/s
 ```
 
 The `loopback` app will log messages over the USB interface. To display these messages on the host we have provided a cross-platform tool: `cargo xtask serial-term`.

--- a/exercise-book/src/nrf52-usb-dma.md
+++ b/exercise-book/src/nrf52-usb-dma.md
@@ -4,7 +4,7 @@
 
 Let's zoom into the `Ep0In` abstraction we used in `usb-3.rs`.
 
-✅ Open the file. Use VSCode's "Go to Definition" to see the implementation of the `Ep0In.start()` method.
+✅ Open the file. Use VSCode's "Go to Definition" to see the implementation of the `Ep0In::start()` method.
 
 This is how data transfers over USB work on the nRF52840: for each endpoint there's a buffer in the USBD peripheral. Data sent by the host over USB to a particular endpoint will be stored in the corresponding endpoint buffer. Likewise, data stored in one of these endpoint buffers can be send to the host over USB from that particular endpoint. These buffers are not directly accessible by the CPU but data stored in RAM can be copied into these buffers; likewise, the contents of an endpoint buffer can be copied into RAM. A second peripheral, the Direct Memory Access (DMA) peripheral, can copy data between these endpoint buffers and RAM. The process of copying data in either direction is referred to as "a DMA transfer".
 

--- a/exercise-book/src/nrf52-usb-listing-usb-devices.md
+++ b/exercise-book/src/nrf52-usb-listing-usb-devices.md
@@ -10,11 +10,11 @@ $ cyme
   2  15  0x1366 0x1051 J-Link                   001050255503      12.0 Mb/s
 ```
 
-The goal of this workshop is to get the nRF52840 SoC to show in this list. The embedded application will use the USB Vendor ID (VID) 0x1209 and USB Product ID (PID) 0x0717, as defined in [`nrf52-code/consts`](../../nrf52-code/consts):
+The goal of this workshop is to get the nRF52840 SoC to show in this list. The embedded application will use the USB Vendor ID (VID) 0x1209 and USB Product ID (PID) 0x0001, as defined in [`nrf52-code/consts`](../../nrf52-code/consts):
 
 ```console
 $ cyme
 (...) random other USB devices will be listed
   2  15  0x1366 0x1051 J-Link                   001050255503      12.0 Mb/s
-  2  16  0x1209 0x0717 composite_device         -                 12.0 Mb/s
+  2  16  0x1209 0x0001 composite_device         -                 12.0 Mb/s
 ````

--- a/exercise-book/src/nrf52-usb-usb-events.md
+++ b/exercise-book/src/nrf52-usb-usb-events.md
@@ -12,7 +12,7 @@ In this starter code the `USBD` peripheral is initialized in `init` and a task, 
 
 This code will panic because `Event::UsbReset` is not handled yet - it has a `todo!()` on the relevant `match` arm.
 
-✅ Go to `fn on_event(...)`, line 48. You'll need to handle the `Event::UsbReset` case - for now, just print the log message _returning to the Default state_.
+✅ Go to `fn on_event(...)`. You'll need to handle the `Event::UsbReset` case - for now, just print the log message _returning to the Default state_.
 
 ✅ Now handle the `Event::UsbEp0Setup` case - for now, just print the log message _usb-1 exercise complete_ and then execute `dk::exit()` to shut down the microcontroller.
 

--- a/nrf52-code/boards/dk-solution/src/usbd.rs
+++ b/nrf52-code/boards/dk-solution/src/usbd.rs
@@ -73,7 +73,7 @@ impl Ep0In {
     /// the hardware
     pub fn end(&mut self, usbd: &USBD) {
         if usbd.events_ep0datadone.read().bits() == 0 {
-            panic!("Ep0In.end called before the EP0DATADONE event was raised");
+            panic!("Ep0In::end called before the EP0DATADONE event was raised");
         } else {
             // DMA transfer complete
             dma_end();
@@ -190,7 +190,7 @@ pub fn next_event(usbd: &USBD) -> Option<Event> {
     }
 
     if usbd.events_ep0datadone.read().bits() != 0 {
-        // this will be cleared by the `Ep0In.end` method
+        // this will be cleared by the `Ep0In::end` method
         // usbd.events_ep0datadone.reset();
 
         return Some(Event::UsbEp0DataDone);

--- a/nrf52-code/boards/dk/src/usbd.rs
+++ b/nrf52-code/boards/dk/src/usbd.rs
@@ -73,7 +73,7 @@ impl Ep0In {
     /// the hardware
     pub fn end(&mut self, usbd: &USBD) {
         if usbd.events_ep0datadone.read().bits() == 0 {
-            panic!("Ep0In.end called before the EP0DATADONE event was raised");
+            panic!("Ep0In::end called before the EP0DATADONE event was raised");
         } else {
             // DMA transfer complete
             dma_end();
@@ -190,7 +190,7 @@ pub fn next_event(usbd: &USBD) -> Option<Event> {
     }
 
     if usbd.events_ep0datadone.read().bits() != 0 {
-        // this will be cleared by the `Ep0In.end` method
+        // this will be cleared by the `Ep0In::end` method
         // usbd.events_ep0datadone.reset();
 
         return Some(Event::UsbEp0DataDone);

--- a/nrf52-code/consts/src/lib.rs
+++ b/nrf52-code/consts/src/lib.rs
@@ -4,10 +4,10 @@
 pub const USB_VID_DEMO: u16 = 0x1209;
 
 /// USB PID for the nRF52840 in USB mode when running the RTIC demo
-pub const USB_PID_RTIC_DEMO: u16 = 0x0717;
+pub const USB_PID_RTIC_DEMO: u16 = 0x0001;
 
 /// USB PID for the Dongle in Loopback mode
-pub const USB_PID_DONGLE_LOOPBACK: u16 = 0x0309;
+pub const USB_PID_DONGLE_LOOPBACK: u16 = 0x0002;
 
 /// USB PID for the Dongle in Puzzle mode
-pub const USB_PID_DONGLE_PUZZLE: u16 = 0x0310;
+pub const USB_PID_DONGLE_PUZZLE: u16 = 0x0003;

--- a/nrf52-code/usb-app-solutions/src/bin/task-state.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/task-state.rs
@@ -51,18 +51,15 @@ mod app {
     fn on_power_event(cx: on_power_event::Context) {
         defmt::println!("POWER event occurred");
 
-        // resources available to this task
-        let resources = cx.local;
+        *cx.local.counter += 1;
 
-        *resources.counter += 1;
-        let n = *resources.counter;
         defmt::println!(
             "on_power_event: cable connected {} time{}",
-            n,
-            if n != 1 { "s" } else { "" }
+            *cx.local.counter,
+            if *cx.local.counter != 1 { "s" } else { "" }
         );
 
         // clear the interrupt flag; otherwise this task will run again after it returns
-        resources.power.events_usbdetected.reset();
+        cx.local.power.events_usbdetected.reset();
     }
 }

--- a/nrf52-code/usb-app-solutions/src/bin/usb-1.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-1.rs
@@ -1,15 +1,17 @@
 #![no_main]
 #![no_std]
 
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Event},
+};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Event},
-    };
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -34,25 +36,24 @@ mod app {
 
     #[task(binds = USBD, local = [usbd])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, event)
         }
     }
+}
 
-    fn on_event(_usbd: &USBD, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(_usbd: &USBD, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            Event::UsbReset => {
-                defmt::println!("returning to the Default state");
-            }
-            Event::UsbEp0Setup => {
-                defmt::println!("usb-1 exercise complete");
-                dk::exit();
-            }
-            Event::UsbEp0DataDone => todo!(),
+    match event {
+        Event::UsbReset => {
+            defmt::println!("returning to the Default state");
         }
+        Event::UsbEp0Setup => {
+            defmt::println!("usb-1 exercise complete");
+            dk::exit();
+        }
+        Event::UsbEp0DataDone => todo!(),
     }
 }

--- a/nrf52-code/usb-app-solutions/src/bin/usb-2.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-2.rs
@@ -1,17 +1,19 @@
 #![no_main]
 #![no_std]
 
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Event},
+};
+
+use usb::{Descriptor, Request};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Event},
-    };
-
-    use usb::{Descriptor, Request};
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -32,50 +34,50 @@ mod app {
 
     #[task(binds = USBD, local = [usbd])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, event)
         }
     }
+}
 
-    fn on_event(usbd: &USBD, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(usbd: &USBD, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            Event::UsbReset => {
-                // nothing to do here at the moment
-            }
+    match event {
+        Event::UsbReset => {
+            // nothing to do here at the moment
+        }
 
-            Event::UsbEp0DataDone => todo!(),
+        Event::UsbEp0DataDone => todo!(),
 
-            Event::UsbEp0Setup => {
-                // the BMREQUESTTYPE register contains information about data recipient, transfer type and direction
-                let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
-                // the BREQUEST register stores the type of the current request (e.g. SET_ADDRESS, GET_DESCRIPTOR, ...)
-                let brequest = usbd.brequest.read().brequest().bits();
-                // wLength denotes the number of bytes to transfer (if any)
-                // composed of a high register (WLENGTHH) and a low register (WLENGTHL)
-                let wlength = (u16::from(usbd.wlengthh.read().wlengthh().bits()) << 8)
-                    | u16::from(usbd.wlengthl.read().wlengthl().bits());
-                // wIndex is a generic index field whose meaning depends on the request type
-                // composed of a high register (WINDEXH) and a low register (WINDEXL)
-                let windex = (u16::from(usbd.windexh.read().windexh().bits()) << 8)
-                    | u16::from(usbd.windexl.read().windexl().bits());
-                // wValue is a generic parameter field meaning depends on the request type (e.g. contains the device
-                // address in SET_ADDRESS requests)
-                // composed of a high register (WVALUEH) and a low register (WVALUEL)
-                let wvalue = (u16::from(usbd.wvalueh.read().wvalueh().bits()) << 8)
-                    | u16::from(usbd.wvaluel.read().wvaluel().bits());
+        Event::UsbEp0Setup => {
+            // the BMREQUESTTYPE register contains information about data recipient, transfer type and direction
+            let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
+            // the BREQUEST register stores the type of the current request (e.g. SET_ADDRESS, GET_DESCRIPTOR, ...)
+            let brequest = usbd.brequest.read().brequest().bits();
+            // wLength denotes the number of bytes to transfer (if any)
+            // composed of a high register (WLENGTHH) and a low register (WLENGTHL)
+            let wlength = (u16::from(usbd.wlengthh.read().wlengthh().bits()) << 8)
+                | u16::from(usbd.wlengthl.read().wlengthl().bits());
+            // wIndex is a generic index field whose meaning depends on the request type
+            // composed of a high register (WINDEXH) and a low register (WINDEXL)
+            let windex = (u16::from(usbd.windexh.read().windexh().bits()) << 8)
+                | u16::from(usbd.windexl.read().windexl().bits());
+            // wValue is a generic parameter field meaning depends on the request type (e.g. contains the device
+            // address in SET_ADDRESS requests)
+            // composed of a high register (WVALUEH) and a low register (WVALUEL)
+            let wvalue = (u16::from(usbd.wvalueh.read().wvalueh().bits()) << 8)
+                | u16::from(usbd.wvaluel.read().wvaluel().bits());
 
-                // NOTE the `dk` crate contains helper functions for the above operations
-                // let bmrequesttype = usbd::bmrequesttype(usbd);
-                // let brequest = usbd::brequest(usbd);
-                // let wlength = usbd::wlength(usbd);
-                // let windex = usbd::windex(usbd);
-                // let wvalue = usbd::wvalue(usbd);
+            // NOTE the `dk` crate contains helper functions for the above operations
+            // let bmrequesttype = usbd::bmrequesttype(usbd);
+            // let brequest = usbd::brequest(usbd);
+            // let wlength = usbd::wlength(usbd);
+            // let windex = usbd::windex(usbd);
+            // let wvalue = usbd::wvalue(usbd);
 
-                defmt::debug!(
+            defmt::debug!(
                     "SETUP: bmrequesttype: 0b{=u8:08b}, brequest: {=u8}, wlength: {=u16}, windex: 0x{=u16:04x}, wvalue: 0x{=u16:04x}",
                     bmrequesttype,
                     brequest,
@@ -84,24 +86,23 @@ mod app {
                     wvalue
                 );
 
-                let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
-                    .expect("Error parsing request");
-                match request {
-                    Request::GetDescriptor { descriptor, length }
-                        if descriptor == Descriptor::Device =>
-                    {
-                        defmt::info!("GET_DESCRIPTOR Device [length={}]", length);
+            let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
+                .expect("Error parsing request");
+            match request {
+                Request::GetDescriptor { descriptor, length }
+                    if descriptor == Descriptor::Device =>
+                {
+                    defmt::info!("GET_DESCRIPTOR Device [length={}]", length);
 
-                        defmt::println!("Goal reached; move to the next section");
-                        dk::exit()
-                    }
-                    Request::SetAddress { .. } => {
-                        // On macOS you'll get this request before the GET_DESCRIPTOR request so we
-                        // need to catch it here. We'll properly handle this request later
-                        // but for now it's OK to do nothing.
-                    }
-                    _ => unreachable!(), // we don't handle any other Requests
+                    defmt::println!("Goal reached; move to the next section");
+                    dk::exit()
                 }
+                Request::SetAddress { .. } => {
+                    // On macOS you'll get this request before the GET_DESCRIPTOR request so we
+                    // need to catch it here. We'll properly handle this request later
+                    // but for now it's OK to do nothing.
+                }
+                _ => unreachable!(), // we don't handle any other Requests
             }
         }
     }

--- a/nrf52-code/usb-app-solutions/src/bin/usb-3.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-3.rs
@@ -1,16 +1,19 @@
 #![no_main]
 #![no_std]
 
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Ep0In, Event},
+};
+
+use usb::{Descriptor, Request};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Ep0In, Event},
-    };
-    use usb::{Descriptor, Request};
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -38,32 +41,31 @@ mod app {
 
     #[task(binds = USBD, local = [usbd, ep0in])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-        let ep0in = cx.local.ep0in;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, ep0in, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, cx.local.ep0in, event)
         }
     }
+}
 
-    fn on_event(usbd: &USBD, ep0in: &mut Ep0In, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(usbd: &USBD, ep0in: &mut Ep0In, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            Event::UsbReset => {
-                // nothing to do here at the moment
-            }
+    match event {
+        Event::UsbReset => {
+            // nothing to do here at the moment
+        }
 
-            Event::UsbEp0DataDone => ep0in.end(usbd),
+        Event::UsbEp0DataDone => ep0in.end(usbd),
 
-            Event::UsbEp0Setup => {
-                let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
-                let brequest = usbd.brequest.read().brequest().bits();
-                let wlength = usbd::wlength(usbd);
-                let windex = usbd::windex(usbd);
-                let wvalue = usbd::wvalue(usbd);
+        Event::UsbEp0Setup => {
+            let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
+            let brequest = usbd.brequest.read().brequest().bits();
+            let wlength = usbd::wlength(usbd);
+            let windex = usbd::windex(usbd);
+            let wvalue = usbd::wvalue(usbd);
 
-                defmt::debug!(
+            defmt::debug!(
                     "SETUP: bmrequesttype: 0b{=u8:08b}, brequest: {=u8}, wlength: {=u16}, windex: 0x{=u16:04x}, wvalue: 0x{=u16:04x}",
                     bmrequesttype,
                     brequest,
@@ -72,44 +74,49 @@ mod app {
                     wvalue
                 );
 
-                let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength).expect(
-                    "Error parsing request (goal achieved if GET_DESCRIPTOR Device was handled before)",
-                );
-                match request {
-                    Request::GetDescriptor { descriptor, length }
-                        if descriptor == Descriptor::Device =>
-                    {
-                        defmt::info!("GET_DESCRIPTOR Device [length={}]", length);
+            let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength).expect(
+                "Error parsing request (goal achieved if GET_DESCRIPTOR Device was handled before)",
+            );
+            match request {
+                Request::GetDescriptor { descriptor, length }
+                    if descriptor == Descriptor::Device =>
+                {
+                    defmt::info!("GET_DESCRIPTOR Device [length={}]", length);
 
-                        let desc = usb2::device::Descriptor {
-                            bDeviceClass: 0,
-                            bDeviceProtocol: 0,
-                            bDeviceSubClass: 0,
-                            bMaxPacketSize0: usb2::device::bMaxPacketSize0::B64,
-                            bNumConfigurations: core::num::NonZeroU8::new(1).unwrap(),
-                            bcdDevice: 0x01_00, // 1.00
-                            iManufacturer: None,
-                            iProduct: None,
-                            iSerialNumber: None,
-                            idProduct: consts::USB_PID_RTIC_DEMO,
-                            idVendor: consts::USB_VID_DEMO,
-                        };
-                        let desc_bytes = desc.bytes();
-                        let resp =
-                            &desc_bytes[..core::cmp::min(desc_bytes.len(), usize::from(length))];
-                        ep0in.start(resp, usbd);
-                    }
-                    Request::SetAddress { .. } => {
-                        // On macOS you'll get this request before the GET_DESCRIPTOR request so we
-                        // need to catch it here. We'll properly handle this request later
-                        // but for now it's OK to do nothing.
-                    }
-                    _ => {
-                        defmt::error!(
+                    let desc = usb2::device::Descriptor {
+                        bDeviceClass: 0,
+                        bDeviceProtocol: 0,
+                        bDeviceSubClass: 0,
+                        bMaxPacketSize0: usb2::device::bMaxPacketSize0::B64,
+                        bNumConfigurations: core::num::NonZeroU8::new(1).unwrap(),
+                        bcdDevice: 0x01_00, // 1.00
+                        iManufacturer: None,
+                        iProduct: None,
+                        iSerialNumber: None,
+                        idProduct: consts::USB_PID_RTIC_DEMO,
+                        idVendor: consts::USB_VID_DEMO,
+                    };
+                    let length = usize::from(length);
+                    let desc_bytes = desc.bytes();
+                    let subslice = if length >= desc_bytes.len() {
+                        // they want all of it
+                        &desc_bytes[0..]
+                    } else {
+                        // they don't want all of it
+                        &desc_bytes[0..length]
+                    };
+                    ep0in.start(subslice, usbd);
+                }
+                Request::SetAddress { .. } => {
+                    // On macOS you'll get this request before the GET_DESCRIPTOR request so we
+                    // need to catch it here. We'll properly handle this request later
+                    // but for now it's OK to do nothing.
+                }
+                _ => {
+                    defmt::error!(
                             "unknown request (goal achieved if GET_DESCRIPTOR Device was handled before)"
                         );
-                        dk::exit()
-                    }
+                    dk::exit()
                 }
             }
         }

--- a/nrf52-code/usb-app-solutions/src/bin/usb-4.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-4.rs
@@ -1,19 +1,24 @@
 #![no_main]
 #![no_std]
 
+use core::num::NonZeroU8;
+
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Ep0In, Event},
+};
+
+use usb2::{GetDescriptor as Descriptor, StandardRequest as Request, State};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
+/// The `bConfigurationValue` of the only supported configuration
+const CONFIG_VAL: u8 = 42;
+
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-
-    use core::num::NonZeroU8;
-
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Ep0In, Event},
-    };
-    use usb2::{GetDescriptor as Descriptor, StandardRequest as Request, State};
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -43,49 +48,45 @@ mod app {
 
     #[task(binds = USBD, local = [usbd, ep0in, state])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-        let ep0in = cx.local.ep0in;
-        let state = cx.local.state;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, ep0in, state, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, cx.local.ep0in, cx.local.state, event)
         }
     }
+}
 
-    fn on_event(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            Event::UsbReset => {
-                defmt::warn!("USB reset condition detected");
-                *state = State::Default;
-            }
+    match event {
+        Event::UsbReset => {
+            defmt::warn!("USB reset condition detected");
+            *state = State::Default;
+        }
 
-            Event::UsbEp0DataDone => {
-                defmt::info!("EP0IN: transfer complete");
-                ep0in.end(usbd);
-            }
+        Event::UsbEp0DataDone => {
+            defmt::info!("EP0IN: transfer complete");
+            ep0in.end(usbd);
+        }
 
-            Event::UsbEp0Setup => {
-                if ep0setup(usbd, ep0in, state).is_err() {
-                    defmt::warn!("EP0IN: unexpected request; stalling the endpoint");
-                    usbd::ep0stall(usbd);
-                }
+        Event::UsbEp0Setup => {
+            if ep0setup(usbd, ep0in, state).is_err() {
+                defmt::warn!("EP0IN: unexpected request; stalling the endpoint");
+                usbd::ep0stall(usbd);
             }
         }
     }
+}
 
-    /// The `bConfigurationValue` of the only supported configuration
-    const CONFIG_VAL: u8 = 42;
+/// Handle a SETUP request on EP0
+fn ep0setup(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State) -> Result<(), ()> {
+    let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
+    let brequest = usbd.brequest.read().brequest().bits();
+    let wlength = usbd::wlength(usbd);
+    let windex = usbd::windex(usbd);
+    let wvalue = usbd::wvalue(usbd);
 
-    fn ep0setup(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State) -> Result<(), ()> {
-        let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
-        let brequest = usbd.brequest.read().brequest().bits();
-        let wlength = usbd::wlength(usbd);
-        let windex = usbd::windex(usbd);
-        let wvalue = usbd::wvalue(usbd);
-
-        defmt::debug!(
+    defmt::debug!(
             "SETUP: bmrequesttype: 0b{=u8:08b}, brequest: {=u8}, wlength: {=u16}, windex: 0x{=u16:04x}, wvalue: 0x{=u16:04x}",
             bmrequesttype,
             brequest,
@@ -94,103 +95,110 @@ mod app {
             wvalue
         );
 
-        let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
-            .expect("Error parsing request");
-        defmt::info!("EP0: {}", defmt::Debug2Format(&request));
-        //                         ^^^^^^^^^^^^^^^^^^^ this adapter is currently needed to log
-        //                                            `Request` with `defmt`
-        match request {
-            // section 9.4.3
-            // this request is valid in any state
-            Request::GetDescriptor {
-                descriptor: Descriptor::Device,
-                length,
-            } => {
-                let desc = usb2::device::Descriptor {
-                    bDeviceClass: 0,
-                    bDeviceProtocol: 0,
-                    bDeviceSubClass: 0,
-                    bMaxPacketSize0: usb2::device::bMaxPacketSize0::B64,
-                    bNumConfigurations: core::num::NonZeroU8::new(1).unwrap(),
-                    bcdDevice: 0x01_00, // 1.00
-                    iManufacturer: None,
-                    iProduct: None,
-                    iSerialNumber: None,
-                    idProduct: consts::USB_PID_RTIC_DEMO,
-                    idVendor: consts::USB_VID_DEMO,
+    let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
+        .expect("Error parsing request");
+    defmt::info!("EP0: {}", defmt::Debug2Format(&request));
+    //                         ^^^^^^^^^^^^^^^^^^^ this adapter is currently needed to log
+    //                                            `Request` with `defmt`
+    match request {
+        // section 9.4.3
+        // this request is valid in any state
+        Request::GetDescriptor {
+            descriptor: Descriptor::Device,
+            length,
+        } => {
+            let desc = usb2::device::Descriptor {
+                bDeviceClass: 0,
+                bDeviceProtocol: 0,
+                bDeviceSubClass: 0,
+                bMaxPacketSize0: usb2::device::bMaxPacketSize0::B64,
+                bNumConfigurations: core::num::NonZeroU8::new(1).unwrap(),
+                bcdDevice: 0x01_00, // 1.00
+                iManufacturer: None,
+                iProduct: None,
+                iSerialNumber: None,
+                idProduct: consts::USB_PID_RTIC_DEMO,
+                idVendor: consts::USB_VID_DEMO,
+            };
+            let length = usize::from(length);
+            let desc_bytes = desc.bytes();
+            let subslice = if length >= desc_bytes.len() {
+                // they want all of it
+                &desc_bytes[0..]
+            } else {
+                // they don't want all of it
+                &desc_bytes[0..length]
+            };
+            ep0in.start(subslice, usbd);
+        }
+        Request::GetDescriptor {
+            descriptor: Descriptor::Configuration { index },
+            length,
+        } => {
+            if index == 0 {
+                let mut resp = heapless::Vec::<u8, 64>::new();
+
+                let conf_desc = usb2::configuration::Descriptor {
+                    wTotalLength: (usb2::configuration::Descriptor::SIZE
+                        + usb2::interface::Descriptor::SIZE)
+                        .into(),
+                    bNumInterfaces: NonZeroU8::new(1).unwrap(),
+                    bConfigurationValue: core::num::NonZeroU8::new(CONFIG_VAL).unwrap(),
+                    iConfiguration: None,
+                    bmAttributes: usb2::configuration::bmAttributes {
+                        self_powered: true,
+                        remote_wakeup: false,
+                    },
+                    bMaxPower: 250, // 500 mA
                 };
-                let bytes = desc.bytes();
-                ep0in.start(&bytes[..core::cmp::min(bytes.len(), length.into())], usbd);
+
+                let iface_desc = usb2::interface::Descriptor {
+                    bInterfaceNumber: 0,
+                    bAlternativeSetting: 0,
+                    bNumEndpoints: 0,
+                    bInterfaceClass: 0,
+                    bInterfaceSubClass: 0,
+                    bInterfaceProtocol: 0,
+                    iInterface: None,
+                };
+
+                resp.extend_from_slice(&conf_desc.bytes()).unwrap();
+                resp.extend_from_slice(&iface_desc.bytes()).unwrap();
+                ep0in.start(&resp[..core::cmp::min(resp.len(), length.into())], usbd);
+            } else {
+                // out of bounds access: stall the endpoint
+                return Err(());
             }
-            Request::GetDescriptor {
-                descriptor: Descriptor::Configuration { index },
-                length,
-            } => {
-                if index == 0 {
-                    let mut resp = heapless::Vec::<u8, 64>::new();
-
-                    let conf_desc = usb2::configuration::Descriptor {
-                        wTotalLength: (usb2::configuration::Descriptor::SIZE
-                            + usb2::interface::Descriptor::SIZE)
-                            .into(),
-                        bNumInterfaces: NonZeroU8::new(1).unwrap(),
-                        bConfigurationValue: core::num::NonZeroU8::new(CONFIG_VAL).unwrap(),
-                        iConfiguration: None,
-                        bmAttributes: usb2::configuration::bmAttributes {
-                            self_powered: true,
-                            remote_wakeup: false,
-                        },
-                        bMaxPower: 250, // 500 mA
-                    };
-
-                    let iface_desc = usb2::interface::Descriptor {
-                        bInterfaceNumber: 0,
-                        bAlternativeSetting: 0,
-                        bNumEndpoints: 0,
-                        bInterfaceClass: 0,
-                        bInterfaceSubClass: 0,
-                        bInterfaceProtocol: 0,
-                        iInterface: None,
-                    };
-
-                    resp.extend_from_slice(&conf_desc.bytes()).unwrap();
-                    resp.extend_from_slice(&iface_desc.bytes()).unwrap();
-                    ep0in.start(&resp[..core::cmp::min(resp.len(), length.into())], usbd);
-                } else {
-                    // out of bounds access: stall the endpoint
-                    return Err(());
-                }
-            }
-            Request::SetAddress { address } => {
-                match state {
-                    State::Default => {
-                        if let Some(address) = address {
-                            *state = State::Address(address);
-                        } else {
-                            // stay in the `Default` state
-                        }
+        }
+        Request::SetAddress { address } => {
+            match state {
+                State::Default => {
+                    if let Some(address) = address {
+                        *state = State::Address(address);
+                    } else {
+                        // stay in the `Default` state
                     }
-
-                    State::Address(..) => {
-                        if let Some(address) = address {
-                            // use the new address
-                            *state = State::Address(address);
-                        } else {
-                            *state = State::Default;
-                        }
-                    }
-
-                    // unspecified behavior
-                    State::Configured { .. } => return Err(()),
                 }
 
-                // the response to this request is handled in hardware
+                State::Address(..) => {
+                    if let Some(address) = address {
+                        // use the new address
+                        *state = State::Address(address);
+                    } else {
+                        *state = State::Default;
+                    }
+                }
+
+                // unspecified behavior
+                State::Configured { .. } => return Err(()),
             }
 
-            // stall any other request
-            _ => return Err(()),
+            // the response to this request is handled in hardware
         }
 
-        Ok(())
+        // stall any other request
+        _ => return Err(()),
     }
+
+    Ok(())
 }

--- a/nrf52-code/usb-app-solutions/src/bin/usb-5.rs
+++ b/nrf52-code/usb-app-solutions/src/bin/usb-5.rs
@@ -1,19 +1,24 @@
 #![no_main]
 #![no_std]
 
+use core::num::NonZeroU8;
+
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Ep0In, Event},
+};
+
+use usb2::{GetDescriptor as Descriptor, StandardRequest as Request, State};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
+/// The `bConfigurationValue` of the only supported configuration
+const CONFIG_VAL: u8 = 42;
+
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-
-    use core::num::NonZeroU8;
-
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Ep0In, Event},
-    };
-    use usb2::{GetDescriptor as Descriptor, StandardRequest as Request, State};
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -43,49 +48,45 @@ mod app {
 
     #[task(binds = USBD, local = [usbd, ep0in, state])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-        let ep0in = cx.local.ep0in;
-        let state = cx.local.state;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, ep0in, state, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, cx.local.ep0in, cx.local.state, event)
         }
     }
+}
 
-    fn on_event(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            Event::UsbReset => {
-                defmt::warn!("USB reset condition detected");
-                *state = State::Default;
-            }
+    match event {
+        Event::UsbReset => {
+            defmt::warn!("USB reset condition detected");
+            *state = State::Default;
+        }
 
-            Event::UsbEp0DataDone => {
-                defmt::info!("EP0IN: transfer complete");
-                ep0in.end(usbd);
-            }
+        Event::UsbEp0DataDone => {
+            defmt::info!("EP0IN: transfer complete");
+            ep0in.end(usbd);
+        }
 
-            Event::UsbEp0Setup => {
-                if ep0setup(usbd, ep0in, state).is_err() {
-                    defmt::warn!("EP0IN: unexpected request; stalling the endpoint");
-                    usbd::ep0stall(usbd);
-                }
+        Event::UsbEp0Setup => {
+            if ep0setup(usbd, ep0in, state).is_err() {
+                defmt::warn!("EP0IN: unexpected request; stalling the endpoint");
+                usbd::ep0stall(usbd);
             }
         }
     }
+}
 
-    /// The `bConfigurationValue` of the only supported configuration
-    const CONFIG_VAL: u8 = 42;
+/// Handle a SETUP request on EP0
+fn ep0setup(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State) -> Result<(), ()> {
+    let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
+    let brequest = usbd.brequest.read().brequest().bits();
+    let wlength = usbd::wlength(usbd);
+    let windex = usbd::windex(usbd);
+    let wvalue = usbd::wvalue(usbd);
 
-    fn ep0setup(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State) -> Result<(), ()> {
-        let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
-        let brequest = usbd.brequest.read().brequest().bits();
-        let wlength = usbd::wlength(usbd);
-        let windex = usbd::windex(usbd);
-        let wvalue = usbd::wvalue(usbd);
-
-        defmt::debug!(
+    defmt::debug!(
             "SETUP: bmrequesttype: 0b{=u8:08b}, brequest: {=u8}, wlength: {=u16}, windex: 0x{=u16:04x}, wvalue: 0x{=u16:04x}",
             bmrequesttype,
             brequest,
@@ -94,150 +95,157 @@ mod app {
             wvalue
         );
 
-        let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
-            .expect("Error parsing request");
-        defmt::info!("EP0: {}", defmt::Debug2Format(&request));
-        //                        ^^^^^^^^^^^^^^^^^^^ this adapter is currently needed to log
-        //                                            `Request` with `defmt`
+    let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
+        .expect("Error parsing request");
+    defmt::info!("EP0: {}", defmt::Debug2Format(&request));
+    //                        ^^^^^^^^^^^^^^^^^^^ this adapter is currently needed to log
+    //                                            `Request` with `defmt`
 
-        match request {
-            // section 9.4.3
-            // this request is valid in any state
-            Request::GetDescriptor {
-                descriptor: Descriptor::Device,
-                length,
-            } => {
-                let desc = usb2::device::Descriptor {
-                    bDeviceClass: 0,
-                    bDeviceProtocol: 0,
-                    bDeviceSubClass: 0,
-                    bMaxPacketSize0: usb2::device::bMaxPacketSize0::B64,
-                    bNumConfigurations: core::num::NonZeroU8::new(1).unwrap(),
-                    bcdDevice: 0x01_00, // 1.00
-                    iManufacturer: None,
-                    iProduct: None,
-                    iSerialNumber: None,
-                    idProduct: consts::USB_PID_RTIC_DEMO,
-                    idVendor: consts::USB_VID_DEMO,
+    match request {
+        // section 9.4.3
+        // this request is valid in any state
+        Request::GetDescriptor {
+            descriptor: Descriptor::Device,
+            length,
+        } => {
+            let desc = usb2::device::Descriptor {
+                bDeviceClass: 0,
+                bDeviceProtocol: 0,
+                bDeviceSubClass: 0,
+                bMaxPacketSize0: usb2::device::bMaxPacketSize0::B64,
+                bNumConfigurations: core::num::NonZeroU8::new(1).unwrap(),
+                bcdDevice: 0x01_00, // 1.00
+                iManufacturer: None,
+                iProduct: None,
+                iSerialNumber: None,
+                idProduct: consts::USB_PID_RTIC_DEMO,
+                idVendor: consts::USB_VID_DEMO,
+            };
+            let length = usize::from(length);
+            let desc_bytes = desc.bytes();
+            let subslice = if length >= desc_bytes.len() {
+                // they want all of it
+                &desc_bytes[0..]
+            } else {
+                // they don't want all of it
+                &desc_bytes[0..length]
+            };
+            ep0in.start(subslice, usbd);
+        }
+        Request::GetDescriptor {
+            descriptor: Descriptor::Configuration { index },
+            length,
+        } => {
+            if index == 0 {
+                let mut resp = heapless::Vec::<u8, 64>::new();
+
+                let conf_desc = usb2::configuration::Descriptor {
+                    wTotalLength: (usb2::configuration::Descriptor::SIZE
+                        + usb2::interface::Descriptor::SIZE)
+                        .into(),
+                    bNumInterfaces: NonZeroU8::new(1).unwrap(),
+                    bConfigurationValue: core::num::NonZeroU8::new(CONFIG_VAL).unwrap(),
+                    iConfiguration: None,
+                    bmAttributes: usb2::configuration::bmAttributes {
+                        self_powered: true,
+                        remote_wakeup: false,
+                    },
+                    bMaxPower: 250, // 500 mA
                 };
-                let bytes = desc.bytes();
-                ep0in.start(&bytes[..core::cmp::min(bytes.len(), length.into())], usbd);
+
+                let iface_desc = usb2::interface::Descriptor {
+                    bInterfaceNumber: 0,
+                    bAlternativeSetting: 0,
+                    bNumEndpoints: 0,
+                    bInterfaceClass: 0,
+                    bInterfaceSubClass: 0,
+                    bInterfaceProtocol: 0,
+                    iInterface: None,
+                };
+
+                resp.extend_from_slice(&conf_desc.bytes()).unwrap();
+                resp.extend_from_slice(&iface_desc.bytes()).unwrap();
+                ep0in.start(&resp[..core::cmp::min(resp.len(), length.into())], usbd);
+            } else {
+                // out of bounds access: stall the endpoint
+                return Err(());
             }
-            Request::GetDescriptor {
-                descriptor: Descriptor::Configuration { index },
-                length,
-            } => {
-                if index == 0 {
-                    let mut resp = heapless::Vec::<u8, 64>::new();
-
-                    let conf_desc = usb2::configuration::Descriptor {
-                        wTotalLength: (usb2::configuration::Descriptor::SIZE
-                            + usb2::interface::Descriptor::SIZE)
-                            .into(),
-                        bNumInterfaces: NonZeroU8::new(1).unwrap(),
-                        bConfigurationValue: core::num::NonZeroU8::new(CONFIG_VAL).unwrap(),
-                        iConfiguration: None,
-                        bmAttributes: usb2::configuration::bmAttributes {
-                            self_powered: true,
-                            remote_wakeup: false,
-                        },
-                        bMaxPower: 250, // 500 mA
-                    };
-
-                    let iface_desc = usb2::interface::Descriptor {
-                        bInterfaceNumber: 0,
-                        bAlternativeSetting: 0,
-                        bNumEndpoints: 0,
-                        bInterfaceClass: 0,
-                        bInterfaceSubClass: 0,
-                        bInterfaceProtocol: 0,
-                        iInterface: None,
-                    };
-
-                    resp.extend_from_slice(&conf_desc.bytes()).unwrap();
-                    resp.extend_from_slice(&iface_desc.bytes()).unwrap();
-                    ep0in.start(&resp[..core::cmp::min(resp.len(), length.into())], usbd);
-                } else {
-                    // out of bounds access: stall the endpoint
-                    return Err(());
-                }
-            }
-            Request::SetAddress { address } => {
-                match state {
-                    State::Default => {
-                        if let Some(address) = address {
-                            *state = State::Address(address);
-                        } else {
-                            // stay in the `Default` state
-                        }
+        }
+        Request::SetAddress { address } => {
+            match state {
+                State::Default => {
+                    if let Some(address) = address {
+                        *state = State::Address(address);
+                    } else {
+                        // stay in the `Default` state
                     }
-
-                    State::Address(..) => {
-                        if let Some(address) = address {
-                            // use the new address
-                            *state = State::Address(address);
-                        } else {
-                            *state = State::Default;
-                        }
-                    }
-
-                    // unspecified behavior
-                    State::Configured { .. } => return Err(()),
                 }
 
-                // the response to this request is handled in hardware
-            }
-            Request::SetConfiguration { value } => {
-                match *state {
-                    // unspecified behavior
-                    State::Default => return Err(()),
+                State::Address(..) => {
+                    if let Some(address) = address {
+                        // use the new address
+                        *state = State::Address(address);
+                    } else {
+                        *state = State::Default;
+                    }
+                }
 
-                    State::Address(address) => {
-                        if let Some(value) = value {
-                            if value.get() == CONFIG_VAL {
-                                defmt::info!("entering the configured state");
-                                *state = State::Configured { address, value };
-                            } else {
-                                defmt::error!("unsupported configuration value");
-                                return Err(());
+                // unspecified behavior
+                State::Configured { .. } => return Err(()),
+            }
+
+            // the response to this request is handled in hardware
+        }
+        Request::SetConfiguration { value } => {
+            match *state {
+                // unspecified behavior
+                State::Default => return Err(()),
+
+                State::Address(address) => {
+                    if let Some(value) = value {
+                        if value.get() == CONFIG_VAL {
+                            defmt::info!("entering the configured state");
+                            *state = State::Configured { address, value };
+                        } else {
+                            defmt::error!("unsupported configuration value");
+                            return Err(());
+                        }
+                    } else {
+                        // stay in the address mode
+                    }
+                }
+
+                State::Configured {
+                    address,
+                    value: curr_value,
+                } => {
+                    if let Some(new_value) = value {
+                        if new_value.get() == CONFIG_VAL {
+                            if new_value != curr_value {
+                                defmt::println!("changing configuration");
+                                *state = State::Configured {
+                                    address,
+                                    value: new_value,
+                                };
                             }
                         } else {
-                            // stay in the address mode
+                            defmt::error!("unsupported configuration value");
+                            return Err(());
                         }
-                    }
-
-                    State::Configured {
-                        address,
-                        value: curr_value,
-                    } => {
-                        if let Some(new_value) = value {
-                            if new_value.get() == CONFIG_VAL {
-                                if new_value != curr_value {
-                                    defmt::println!("changing configuration");
-                                    *state = State::Configured {
-                                        address,
-                                        value: new_value,
-                                    };
-                                }
-                            } else {
-                                defmt::error!("unsupported configuration value");
-                                return Err(());
-                            }
-                        } else {
-                            defmt::println!("returned to the address state");
-                            *state = State::Address(address);
-                        }
+                    } else {
+                        defmt::println!("returned to the address state");
+                        *state = State::Address(address);
                     }
                 }
-
-                usbd.tasks_ep0status
-                    .write(|w| w.tasks_ep0status().set_bit());
             }
 
-            // stall any other request
-            _ => return Err(()),
+            usbd.tasks_ep0status
+                .write(|w| w.tasks_ep0status().set_bit());
         }
 
-        Ok(())
+        // stall any other request
+        _ => return Err(()),
     }
+
+    Ok(())
 }

--- a/nrf52-code/usb-app/src/bin/task-state.rs
+++ b/nrf52-code/usb-app/src/bin/task-state.rs
@@ -44,10 +44,7 @@ mod app {
     fn on_power_event(cx: on_power_event::Context) {
         defmt::println!("POWER event occurred");
 
-        // resources available to this task
-        let resources = cx.local;
-
         // clear the interrupt flag; otherwise this task will run again after it returns
-        resources.power.events_usbdetected.reset();
+        cx.local.power.events_usbdetected.reset();
     }
 }

--- a/nrf52-code/usb-app/src/bin/usb-1.rs
+++ b/nrf52-code/usb-app/src/bin/usb-1.rs
@@ -1,15 +1,17 @@
 #![no_main]
 #![no_std]
 
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Event},
+};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Event},
-    };
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -34,20 +36,19 @@ mod app {
 
     #[task(binds = USBD, local = [usbd])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, event)
         }
     }
+}
 
-    fn on_event(_usbd: &USBD, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(_usbd: &USBD, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            Event::UsbReset => todo!(),
-            Event::UsbEp0Setup => todo!(),
-            Event::UsbEp0DataDone => todo!(),
-        }
+    match event {
+        Event::UsbReset => todo!(),
+        Event::UsbEp0Setup => todo!(),
+        Event::UsbEp0DataDone => todo!(),
     }
 }

--- a/nrf52-code/usb-app/src/bin/usb-2.rs
+++ b/nrf52-code/usb-app/src/bin/usb-2.rs
@@ -1,17 +1,19 @@
 #![no_main]
 #![no_std]
 
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Event},
+};
+
+use usb::{Descriptor, Request};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Event},
-    };
-
-    use usb::{Descriptor, Request};
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -32,42 +34,42 @@ mod app {
 
     #[task(binds = USBD, local = [usbd])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, event)
         }
     }
+}
 
-    fn on_event(_usbd: &USBD, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(_usbd: &USBD, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            Event::UsbReset => {
-                // nothing to do here at the moment
-            }
+    match event {
+        Event::UsbReset => {
+            // nothing to do here at the moment
+        }
 
-            Event::UsbEp0DataDone => todo!(),
+        Event::UsbEp0DataDone => todo!(),
 
-            Event::UsbEp0Setup => {
-                // TODO read USBD registers
+        Event::UsbEp0Setup => {
+            // TODO read USBD registers
 
-                // the BMREQUESTTYPE register contains information about data recipient, transfer type and direction
-                let bmrequesttype: u8 = 0;
-                // the BREQUEST register stores the type of the current request (e.g. SET_ADDRESS, GET_DESCRIPTOR, ...)
-                let brequest: u8 = 0;
-                // wLength denotes the number of bytes to transfer (if any)
-                // composed of a high register (WLENGTHH) and a low register (WLENGTHL)
-                let wlength: u16 = 0;
-                // wIndex is a generic index field whose meaning depends on the request type
-                // composed of a high register (WINDEXH) and a low register (WINDEXL)
-                let windex: u16 = 0;
-                // wValue is a generic parameter field meaning depends on the request type (e.g. contains the device
-                // address in SET_ADDRESS requests)
-                // composed of a high register (WVALUEH) and a low register (WVALUEL)
-                let wvalue: u16 = 0;
+            // the BMREQUESTTYPE register contains information about data recipient, transfer type and direction
+            let bmrequesttype: u8 = 0;
+            // the BREQUEST register stores the type of the current request (e.g. SET_ADDRESS, GET_DESCRIPTOR, ...)
+            let brequest: u8 = 0;
+            // wLength denotes the number of bytes to transfer (if any)
+            // composed of a high register (WLENGTHH) and a low register (WLENGTHL)
+            let wlength: u16 = 0;
+            // wIndex is a generic index field whose meaning depends on the request type
+            // composed of a high register (WINDEXH) and a low register (WINDEXL)
+            let windex: u16 = 0;
+            // wValue is a generic parameter field meaning depends on the request type (e.g. contains the device
+            // address in SET_ADDRESS requests)
+            // composed of a high register (WVALUEH) and a low register (WVALUEL)
+            let wvalue: u16 = 0;
 
-                defmt::debug!(
+            defmt::debug!(
                     "SETUP: bmrequesttype: 0b{=u8:08b}, brequest: {=u8}, wlength: {=u16}, windex: 0x{=u16:04x}, wvalue: 0x{=u16:04x}",
                     bmrequesttype,
                     brequest,
@@ -76,27 +78,26 @@ mod app {
                     wvalue
                 );
 
-                let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
-                    .expect("Error parsing request");
-                match request {
-                    Request::GetDescriptor { descriptor, length }
-                        if descriptor == Descriptor::Device =>
-                    {
-                        // TODO modify `Request::parse()` in `nrf52-code/usb-lib/src/lib.rs`
-                        // so that this branch is reached
+            let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
+                .expect("Error parsing request");
+            match request {
+                Request::GetDescriptor { descriptor, length }
+                    if descriptor == Descriptor::Device =>
+                {
+                    // TODO modify `Request::parse()` in `nrf52-code/usb-lib/src/lib.rs`
+                    // so that this branch is reached
 
-                        defmt::info!("GET_DESCRIPTOR Device [length={}]", length);
+                    defmt::info!("GET_DESCRIPTOR Device [length={}]", length);
 
-                        defmt::println!("Goal reached; move to the next section");
-                        dk::exit()
-                    }
-                    Request::SetAddress { .. } => {
-                        // On macOS you'll get this request before the GET_DESCRIPTOR request so we
-                        // need to catch it here. We'll properly handle this request later
-                        // but for now it's OK to do nothing.
-                    }
-                    _ => unreachable!(), // we don't handle any other Requests
+                    defmt::println!("Goal reached; move to the next section");
+                    dk::exit()
                 }
+                Request::SetAddress { .. } => {
+                    // On macOS you'll get this request before the GET_DESCRIPTOR request so we
+                    // need to catch it here. We'll properly handle this request later
+                    // but for now it's OK to do nothing.
+                }
+                _ => unreachable!(), // we don't handle any other Requests
             }
         }
     }

--- a/nrf52-code/usb-app/src/bin/usb-3.rs
+++ b/nrf52-code/usb-app/src/bin/usb-3.rs
@@ -1,16 +1,19 @@
 #![no_main]
 #![no_std]
 
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Ep0In, Event},
+};
+
+use usb::{Descriptor, Request};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Ep0In, Event},
-    };
-    use usb::{Descriptor, Request};
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -38,32 +41,31 @@ mod app {
 
     #[task(binds = USBD, local = [usbd, ep0in])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-        let ep0in = cx.local.ep0in;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, ep0in, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, cx.local.ep0in, event)
         }
     }
+}
 
-    fn on_event(usbd: &USBD, ep0in: &mut Ep0In, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(usbd: &USBD, ep0in: &mut Ep0In, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            Event::UsbReset => {
-                // nothing to do here at the moment
-            }
+    match event {
+        Event::UsbReset => {
+            // nothing to do here at the moment
+        }
 
-            Event::UsbEp0DataDone => todo!(), // <- TODO
+        Event::UsbEp0DataDone => todo!(), // <- TODO
 
-            Event::UsbEp0Setup => {
-                let bmrequesttype = usbd::bmrequesttype(usbd);
-                let brequest = usbd::brequest(usbd);
-                let wlength = usbd::wlength(usbd);
-                let windex = usbd::windex(usbd);
-                let wvalue = usbd::wvalue(usbd);
+        Event::UsbEp0Setup => {
+            let bmrequesttype = usbd::bmrequesttype(usbd);
+            let brequest = usbd::brequest(usbd);
+            let wlength = usbd::wlength(usbd);
+            let windex = usbd::windex(usbd);
+            let wvalue = usbd::wvalue(usbd);
 
-                defmt::debug!(
+            defmt::debug!(
                     "SETUP: bmrequesttype: 0b{=u8:08b}, brequest: {=u8}, wlength: {=u16}, windex: 0x{=u16:04x}, wvalue: 0x{=u16:04x}",
                     bmrequesttype,
                     brequest,
@@ -72,31 +74,30 @@ mod app {
                     wvalue
                 );
 
-                let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength).expect(
-                    "Error parsing request (goal achieved if GET_DESCRIPTOR Device was handled before)",
-                );
-                match request {
-                    Request::GetDescriptor { descriptor, length }
-                        if descriptor == Descriptor::Device =>
-                    {
-                        defmt::info!("GET_DESCRIPTOR Device [length={}]", length);
+            let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength).expect(
+                "Error parsing request (goal achieved if GET_DESCRIPTOR Device was handled before)",
+            );
+            match request {
+                Request::GetDescriptor { descriptor, length }
+                    if descriptor == Descriptor::Device =>
+                {
+                    defmt::info!("GET_DESCRIPTOR Device [length={}]", length);
 
-                        // TODO send back a valid device descriptor, truncated to `length` bytes
-                        // let desc = usb2::device::Descriptor { .. };
-                        let resp = [];
-                        ep0in.start(&resp, usbd);
-                    }
-                    Request::SetAddress { .. } => {
-                        // On macOS you'll get this request before the GET_DESCRIPTOR request so we
-                        // need to catch it here. We'll properly handle this request later
-                        // but for now it's OK to do nothing.
-                    }
-                    _ => {
-                        defmt::error!(
+                    // TODO send back a valid device descriptor, truncated to `length` bytes
+                    // let desc = usb2::device::Descriptor { .. };
+                    let resp = [];
+                    ep0in.start(&resp, usbd);
+                }
+                Request::SetAddress { .. } => {
+                    // On macOS you'll get this request before the GET_DESCRIPTOR request so we
+                    // need to catch it here. We'll properly handle this request later
+                    // but for now it's OK to do nothing.
+                }
+                _ => {
+                    defmt::error!(
                             "unknown request (goal achieved if GET_DESCRIPTOR Device was handled before)"
                         );
-                        dk::exit()
-                    }
+                    dk::exit()
                 }
             }
         }

--- a/nrf52-code/usb-app/src/bin/usb-4.rs
+++ b/nrf52-code/usb-app/src/bin/usb-4.rs
@@ -12,7 +12,7 @@ mod app {
         usbd::{self, Ep0In, Event},
     };
     use usb2::State;
-    // HEADS UP to use *your* USB packet parser uncomment line 12 and remove line 13
+    // HEADS UP to use *your* USB packet parser swap the two lines below
     // use usb::{Request, Descriptor};
     use usb2::{GetDescriptor as Descriptor, StandardRequest as Request};
 

--- a/nrf52-code/usb-app/src/bin/usb-4.rs
+++ b/nrf52-code/usb-app/src/bin/usb-4.rs
@@ -1,20 +1,23 @@
 #![no_main]
 #![no_std]
 
+use dk::{
+    peripheral::USBD,
+    usbd::{self, Ep0In, Event},
+};
+
+use usb2::State;
+
+// HEADS UP to use *your* USB packet parser swap the two lines below
+// use usb::{Request, Descriptor};
+use usb2::{GetDescriptor as Descriptor, StandardRequest as Request};
+
 // this imports `src/lib.rs`to retrieve our global logger + panicking-behavior
 use usb_app as _;
 
 #[rtic::app(device = dk, peripherals = false)]
 mod app {
-
-    use dk::{
-        peripheral::USBD,
-        usbd::{self, Ep0In, Event},
-    };
-    use usb2::State;
-    // HEADS UP to use *your* USB packet parser swap the two lines below
-    // use usb::{Request, Descriptor};
-    use usb2::{GetDescriptor as Descriptor, StandardRequest as Request};
+    use super::*;
 
     #[local]
     struct MyLocalResources {
@@ -44,48 +47,47 @@ mod app {
 
     #[task(binds = USBD, local = [usbd, ep0in, state])]
     fn handle_usb_interrupt(cx: handle_usb_interrupt::Context) {
-        let usbd = cx.local.usbd;
-        let ep0in = cx.local.ep0in;
-        let state = cx.local.state;
-
-        while let Some(event) = usbd::next_event(usbd) {
-            on_event(usbd, ep0in, state, event)
+        while let Some(event) = usbd::next_event(cx.local.usbd) {
+            on_event(cx.local.usbd, cx.local.ep0in, cx.local.state, event)
         }
     }
+}
 
-    fn on_event(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State, event: Event) {
-        defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
+/// Handle a USB event (in interrupt context)
+fn on_event(usbd: &USBD, ep0in: &mut Ep0In, state: &mut State, event: Event) {
+    defmt::debug!("USB: {} @ {=u64:tus}", event, dk::uptime_us());
 
-        match event {
-            // TODO change `state` as specified in chapter 9.1 USB Device States, of the USB specification
-            Event::UsbReset => {
-                defmt::warn!("USB reset condition detected");
-                todo!();
-            }
+    match event {
+        // TODO change `state` as specified in chapter 9.1 USB Device States, of the USB specification
+        Event::UsbReset => {
+            defmt::warn!("USB reset condition detected");
+            todo!();
+        }
 
-            Event::UsbEp0DataDone => {
-                defmt::info!("EP0IN: transfer complete");
-                ep0in.end(usbd);
-            }
+        Event::UsbEp0DataDone => {
+            defmt::info!("EP0IN: transfer complete");
+            ep0in.end(usbd);
+        }
 
-            Event::UsbEp0Setup => {
-                if ep0setup(usbd, ep0in, state).is_err() {
-                    // unsupported or invalid request:
-                    // TODO: add code to stall the endpoint
-                    defmt::warn!("EP0IN: unexpected request; stalling the endpoint");
-                }
+        Event::UsbEp0Setup => {
+            if ep0setup(usbd, ep0in, state).is_err() {
+                // unsupported or invalid request:
+                // TODO: add code to stall the endpoint
+                defmt::warn!("EP0IN: unexpected request; stalling the endpoint");
             }
         }
     }
+}
 
-    fn ep0setup(usbd: &USBD, ep0in: &mut Ep0In, _state: &mut State) -> Result<(), ()> {
-        let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
-        let brequest = usbd.brequest.read().brequest().bits();
-        let wlength = usbd::wlength(usbd);
-        let windex = usbd::windex(usbd);
-        let wvalue = usbd::wvalue(usbd);
+/// Handle a SETUP request on EP0
+fn ep0setup(usbd: &USBD, ep0in: &mut Ep0In, _state: &mut State) -> Result<(), ()> {
+    let bmrequesttype = usbd.bmrequesttype.read().bits() as u8;
+    let brequest = usbd.brequest.read().brequest().bits();
+    let wlength = usbd::wlength(usbd);
+    let windex = usbd::windex(usbd);
+    let wvalue = usbd::wvalue(usbd);
 
-        defmt::debug!(
+    defmt::debug!(
             "SETUP: bmrequesttype: 0b{=u8:08b}, brequest: {=u8}, wlength: {=u16}, windex: 0x{=u16:04x}, wvalue: 0x{=u16:04x}",
             bmrequesttype,
             brequest,
@@ -94,53 +96,60 @@ mod app {
             wvalue
         );
 
-        let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
-            .expect("Error parsing request");
-        defmt::info!("EP0: {}", defmt::Debug2Format(&request));
-        //                        ^^^^^^^^^^^^^^^^^^^ this adapter is currently needed to log
-        //                                            `StandardRequest` with `defmt`
+    let request = Request::parse(bmrequesttype, brequest, wvalue, windex, wlength)
+        .expect("Error parsing request");
+    defmt::info!("EP0: {}", defmt::Debug2Format(&request));
+    //                        ^^^^^^^^^^^^^^^^^^^ this adapter is currently needed to log
+    //                                            `StandardRequest` with `defmt`
 
-        match request {
-            Request::GetDescriptor {
-                descriptor: Descriptor::Device,
-                length,
-            } => {
-                let desc = usb2::device::Descriptor {
-                    bDeviceClass: 0,
-                    bDeviceProtocol: 0,
-                    bDeviceSubClass: 0,
-                    bMaxPacketSize0: usb2::device::bMaxPacketSize0::B64,
-                    bNumConfigurations: core::num::NonZeroU8::new(1).unwrap(),
-                    bcdDevice: 0x01_00, // 1.00
-                    iManufacturer: None,
-                    iProduct: None,
-                    iSerialNumber: None,
-                    idProduct: consts::USB_PID_RTIC_DEMO,
-                    idVendor: consts::USB_VID_DEMO,
-                };
-                let bytes = desc.bytes();
-                ep0in.start(&bytes[..core::cmp::min(bytes.len(), length.into())], usbd);
-            }
-            // TODO implement Configuration descriptor
-            Request::GetDescriptor {
-                // descriptor: Descriptor::Configuration { index },
-                descriptor: _,
-                length: _,
-            } => {
-                return Err(());
-            }
-            Request::SetAddress { .. } => {
-                // On macOS you'll get this request before the GET_DESCRIPTOR request so we
-                // need to catch it here.
+    match request {
+        Request::GetDescriptor {
+            descriptor: Descriptor::Device,
+            length,
+        } => {
+            let desc = usb2::device::Descriptor {
+                bDeviceClass: 0,
+                bDeviceProtocol: 0,
+                bDeviceSubClass: 0,
+                bMaxPacketSize0: usb2::device::bMaxPacketSize0::B64,
+                bNumConfigurations: core::num::NonZeroU8::new(1).unwrap(),
+                bcdDevice: 0x01_00, // 1.00
+                iManufacturer: None,
+                iProduct: None,
+                iSerialNumber: None,
+                idProduct: consts::USB_PID_RTIC_DEMO,
+                idVendor: consts::USB_VID_DEMO,
+            };
+            let length = usize::from(length);
+            let bytes = desc.bytes();
+            let subslice = if length >= bytes.len() {
+                // they want all of it
+                &bytes[0..]
+            } else {
+                // they don't want all of it
+                &bytes[0..length]
+            };
+            ep0in.start(subslice, usbd);
+        }
+        // TODO implement Configuration descriptor
+        Request::GetDescriptor {
+            // descriptor: Descriptor::Configuration { index },
+            descriptor: _,
+            length: _,
+        } => {
+            return Err(());
+        }
+        Request::SetAddress { .. } => {
+            // On macOS you'll get this request before the GET_DESCRIPTOR request so we
+            // need to catch it here.
 
-                // TODO: handle this request properly now.
-                todo!()
-            }
-
-            // stall any other request
-            _ => return Err(()),
+            // TODO: handle this request properly now.
+            todo!()
         }
 
-        Ok(())
+        // stall any other request
+        _ => return Err(()),
     }
+
+    Ok(())
 }


### PR DESCRIPTION
) Bring functions outside RTIC macro module. To show that you don't have
  to do everything inside the module.

) removes some of the variable aliasing that just caused confusion.

) do the descriptor slicing in a more readable way.

) fix some typos

Closes a bunch of points in #148 