### PR TITLE
Update all criticalup.toml files to use Ferrocene 25.05

### DIFF
--- a/qemu-code/uart-driver/criticalup.toml
+++ b/qemu-code/uart-driver/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "stable-25.02.0"
+release = "stable-25.05.0"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",


### PR DESCRIPTION
Ferrocene 25.05 is the next release - updating to check everything still works.