### PR TITLE
better dongle device name

### DIFF
--- a/nrf52-code/loopback-fw/src/main.rs
+++ b/nrf52-code/loopback-fw/src/main.rs
@@ -129,7 +129,7 @@ mod app {
         defmt::debug!("Building USB Strings...");
         let strings = usb_device::device::StringDescriptors::new(usb_device::LangID::EN)
             .manufacturer("Ferrous Systems")
-            .product("Test Device");
+            .product("Dongle Loopback");
 
         defmt::debug!("Building VID and PID...");
         let vid_pid =


### PR DESCRIPTION
The nRF52840 Dongle Device chapter specifies that the dongle should have the Dongle Loopback name, but it is currently named Test Device.