### PR TITLE
Small fixes

### DIFF
--- a/exercise-book/src/nrf52-tools.md
+++ b/exercise-book/src/nrf52-tools.md
@@ -116,10 +116,10 @@ cargo install nrfdfu
 cargo install cyme
 ```
 
-Install `probe-rs` 0.27 pre-compiled binaries on Linux with:
+Install `probe-rs` 0.29.1 pre-compiled binaries on Linux with:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.27.0/probe-rs-tools-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.29.1/probe-rs-tools-installer.sh | sh
 ```
 
 ---
@@ -192,10 +192,10 @@ cargo install nrfdfu
 cargo install cyme
 ```
 
-Install `probe-rs` 0.27 pre-compiled binaries on Windows with:
+Install `probe-rs` 0.29.1 pre-compiled binaries on Windows with:
 
 ```bash
-powershell -c "irm https://github.com/probe-rs/probe-rs/releases/download/v0.27.0/probe-rs-tools-installer.ps1 | iex"
+powershell -c "irm https://github.com/probe-rs/probe-rs/releases/download/v0.29.1/probe-rs-tools-installer.ps1 | iex"
 ```
 
 ---
@@ -241,10 +241,10 @@ cargo install nrfdfu
 cargo install cyme
 ```
 
-Install `probe-rs` 0.27 pre-compiled binaries on macOS with:
+Install `probe-rs` 0.29.1 pre-compiled binaries on macOS with:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.27.0/probe-rs-tools-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.29.1/probe-rs-tools-installer.sh | sh
 ```
 
 ---

--- a/justfile
+++ b/justfile
@@ -37,10 +37,10 @@ format-check: format-check-rust
 format: format-rust
 
 clean: clean-rust
-	rm -rf ./training-book/book
+	rm -rf ./exercise-book/book
 
 serve:
-	cd training-book && mdbook serve
+	cd exercise-book && mdbook serve
 
 build-mdbook:
 	cd exercise-book && RUST_LOG=info mdbook build

--- a/nrf52-code/puzzle-fw/src/main.rs
+++ b/nrf52-code/puzzle-fw/src/main.rs
@@ -148,7 +148,7 @@ mod app {
 
         defmt::debug!("Building VID and PID...");
         let vid_pid =
-            usb_device::device::UsbVidPid(consts::USB_VID_DEMO, consts::USB_PID_DONGLE_LOOPBACK);
+            usb_device::device::UsbVidPid(consts::USB_VID_DEMO, consts::USB_PID_DONGLE_PUZZLE);
 
         defmt::debug!("Building USB Device...");
         let usb_device = usb_device::device::UsbDeviceBuilder::new(usb_alloc, vid_pid)


### PR DESCRIPTION
* Fixes `just serve`
* Fixes the USB PID of the puzzle-fw
* Tells people to install probe-rs 0.29.1 rather than 0.27
