### PR TITLE
Use armv8r-none-eabihf from nightly

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -47,8 +47,9 @@ runs:
       shell: bash
       env:
         RUSTUP_TARGET: ${{ inputs.target }}
+        RUSTUP_CHANNEL: ${{ inputs.channel }}
       run: |
-        rustup target add ${RUSTUP_TARGET}
+        rustup target add ${RUSTUP_TARGET} --toolchain=${RUSTUP_CHANNEL}
     - name: Setup Rust Cache
       if: ${{ inputs.cache != '' }}
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -99,8 +99,8 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache: qemu-code/uart-driver
-          target: thumbv7em-none-eabihf
-      - run: rustup component add rust-src
+          target: armv8r-none-eabihf
+          channel: nightly
       - run: just build-qemu-uart-driver
 
   build-radio-app:

--- a/justfile
+++ b/justfile
@@ -65,10 +65,10 @@ test-multi-threaded-mailbox:
 		cd exercise-solutions/multi-threaded-mailbox && cargo test
 
 build-qemu-uart-driver:
-	cd qemu-code/uart-driver && RUSTC_BOOTSTRAP=1 cargo +stable build --release -Zbuild-std=core
+	cd qemu-code/uart-driver && cargo +nightly build --release
 
 build-qemu-uart-driver-ferrocene:
-	cd qemu-code/uart-driver && cargo build --release
+	cd qemu-code/uart-driver && criticalup install && criticalup run cargo build --release
 
 build-radio-app:
 	cd nrf52-code/radio-app && cargo build --release

--- a/qemu-code/uart-driver/README.md
+++ b/qemu-code/uart-driver/README.md
@@ -28,10 +28,11 @@ We use `criticalup link create` to teach `rustup` that `+ferrocene` means 'use c
 ### Rust
 
 If you want to run it with the upstream Rust compiler, you will need to use
-`nightly`, and tell `cargo` to build the standard library from source:
+`nightly` (or it should be available in stable from Rust 1.92 onwards).
 
 ```bash
-cargo +nightly run -Zbuild-std=core
+rustup target add armv8r-none-eabihf --toolchain=nightly
+cargo +nightly run
 ```
 
 ## License

--- a/qemu-code/uart-driver/criticalup.toml
+++ b/qemu-code/uart-driver/criticalup.toml
@@ -1,7 +1,7 @@
 manifest-version = 1
 
 [products.ferrocene]
-release = "stable-25.05.0"
+release = "stable-25.08.0"
 packages = [
     "rustc-${rustc-host}",
     "rust-std-${rustc-host}",


### PR DESCRIPTION
The change to get rust-std for armv8r-none-eabihf through rustup just landed, so let's use it and stop doing `-Zbuild-std`.

We can switch to stable in about eight weeks time.
