### PR TITLE
Fix radio timeout

### DIFF
--- a/nrf52-code/boards/dk-solution/src/lib.rs
+++ b/nrf52-code/boards/dk-solution/src/lib.rs
@@ -179,10 +179,10 @@ impl Timer {
 
     /// Start the timer with the given microsecond duration.
     pub fn start(&mut self, microseconds: u32) {
-        self.0.cc(0).clear_events();
+        self.0.stop();
+        self.0.clear();
         self.0.cc(0).write(microseconds);
-        self.0.task_clear();
-        self.0.task_start();
+        self.0.start();
     }
 
     /// If the timer has finished, resets it and returns true.

--- a/nrf52-code/boards/dk-solution/src/radio.rs
+++ b/nrf52-code/boards/dk-solution/src/radio.rs
@@ -454,11 +454,15 @@ impl<'d> Radio<'d> {
             // Check if either receive is done or timeout occured
             loop {
                 match recv.is_done() {
-                    Ok(crc) => break Ok(crc),
-                    Err(err) => match err {
-                        nb::Error::Other(crc) => break Err(Error::Crc(crc)),
-                        nb::Error::WouldBlock => (),
-                    },
+                    Ok(crc) => {
+                        break Ok(crc);
+                    }
+                    Err(nb::Error::Other(crc)) => {
+                        break Err(Error::Crc(crc));
+                    }
+                    Err(nb::Error::WouldBlock) => {
+                        // do nothing
+                    }
                 }
 
                 if timer.reset_if_finished() {

--- a/nrf52-code/boards/dk/src/lib.rs
+++ b/nrf52-code/boards/dk/src/lib.rs
@@ -151,10 +151,10 @@ impl Timer {
 
     /// Start the timer with the given microsecond duration.
     pub fn start(&mut self, microseconds: u32) {
-        self.0.cc(0).clear_events();
+        self.0.stop();
+        self.0.clear();
         self.0.cc(0).write(microseconds);
-        self.0.task_clear();
-        self.0.task_start();
+        self.0.start();
     }
 
     /// If the timer has finished, resets it and returns true.

--- a/nrf52-code/boards/dk/src/radio.rs
+++ b/nrf52-code/boards/dk/src/radio.rs
@@ -454,11 +454,15 @@ impl<'d> Radio<'d> {
             // Check if either receive is done or timeout occured
             loop {
                 match recv.is_done() {
-                    Ok(crc) => break Ok(crc),
-                    Err(err) => match err {
-                        nb::Error::Other(crc) => break Err(Error::Crc(crc)),
-                        nb::Error::WouldBlock => (),
-                    },
+                    Ok(crc) => {
+                        break Ok(crc);
+                    }
+                    Err(nb::Error::Other(crc)) => {
+                        break Err(Error::Crc(crc));
+                    }
+                    Err(nb::Error::WouldBlock) => {
+                        // do nothing
+                    }
                 }
 
                 if timer.reset_if_finished() {


### PR DESCRIPTION
Fixes #243 

It was a simple typo - the code was reading the task register instead of firing the task (which you do by writing to it).

cc @robamu 
