### PR TITLE
Remove redundant curl arguments.

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,7 +29,7 @@ runs:
       env:
         CRITICALUP_VERSION: ${{ inputs.criticalup }}
       run: |
-        curl --proto '=https' --tlsv1.2 -LsSf https://github.com/ferrocene/criticalup/releases/download/${CRITICALUP_VERSION}/criticalup-installer.sh | sh
+        curl -fsSL https://github.com/ferrocene/criticalup/releases/download/${CRITICALUP_VERSION}/criticalup-installer.sh | sh
     - name: Install Just 1.42
       uses: extractions/setup-just@v3
       with:

--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -11,11 +11,11 @@ set -euo pipefail
 
 # We only support macOS (the x86 binaries work OK on Apple Silicon), or x86-64 Linux
 if [ $(uname) == "Darwin" ]; then
-    ./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-apple-darwin.tar.gz | tar -xvzf -
-    ./mdbook-mermaid --version || curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.13.0/mdbook-mermaid-v0.13.0-x86_64-apple-darwin.tar.gz | tar -xvzf -
+    ./mdbook --version || curl -fsSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-apple-darwin.tar.gz | tar -xvzf -
+    ./mdbook-mermaid --version || curl -fsSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.13.0/mdbook-mermaid-v0.13.0-x86_64-apple-darwin.tar.gz | tar -xvzf -
 else
-    ./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
-    ./mdbook-mermaid --version || curl -sSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.13.0/mdbook-mermaid-v0.13.0-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
+    ./mdbook --version || curl -fsSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
+    ./mdbook-mermaid --version || curl -fsSL https://github.com/badboy/mdbook-mermaid/releases/download/v0.13.0/mdbook-mermaid-v0.13.0-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
 fi
 
 # Must be an absolute path, otherwise mdbook puts the output in the wrong place

--- a/exercise-book/src/nrf52-tools.md
+++ b/exercise-book/src/nrf52-tools.md
@@ -119,7 +119,7 @@ cargo install cyme
 Install `probe-rs` 0.29.1 pre-compiled binaries on Linux with:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.29.1/probe-rs-tools-installer.sh | sh
+curl -fsSL https://github.com/probe-rs/probe-rs/releases/download/v0.30.0/probe-rs-tools-installer.sh | sh
 ```
 
 ---
@@ -195,7 +195,7 @@ cargo install cyme
 Install `probe-rs` 0.29.1 pre-compiled binaries on Windows with:
 
 ```bash
-powershell -c "irm https://github.com/probe-rs/probe-rs/releases/download/v0.29.1/probe-rs-tools-installer.ps1 | iex"
+powershell -c "irm https://github.com/probe-rs/probe-rs/releases/download/v0.30.0/probe-rs-tools-installer.ps1 | iex"
 ```
 
 ---
@@ -244,7 +244,7 @@ cargo install cyme
 Install `probe-rs` 0.29.1 pre-compiled binaries on macOS with:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/probe-rs/probe-rs/releases/download/v0.29.1/probe-rs-tools-installer.sh | sh
+curl -fsSL https://github.com/probe-rs/probe-rs/releases/download/v0.30.0/probe-rs-tools-installer.sh | sh
 ```
 
 ---


### PR DESCRIPTION
* `-s` for silent mode
* `-S` for showing errors
* `-L` for following redirects
* `-f` for fail on error

SSL is the default and doesn't need to be specified.
