### PR TITLE
Use patched mdbook

### DIFF
--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -49,9 +49,11 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           cache: exercise-book
+      - run: curl -sSL  https://github.com/jonathanpallant/mdBook/releases/download/v0.5.2-current-page-active/mdbook -o ~/.cargo/bin/mdbook
+      - run: chmod a+x ~/.cargo/bin/mdbook
       - uses: taiki-e/install-action@v2
         with:
-          tool: mdbook@0.5.2,mdbook-graphviz@0.3.1
+          tool: mdbook-graphviz@0.3.1
       - run: just test-mdbook
       - run: just build-mdbook
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/weekly-canary-build.yml
+++ b/.github/workflows/weekly-canary-build.yml
@@ -31,10 +31,12 @@ jobs:
         with:
           cache: exercise-book
           channel: ${{ matrix.rust-channel }}
-      - name: Install mdbook, mdbook-graphviz
+      - run: curl -sSL  https://github.com/jonathanpallant/mdBook/releases/download/v0.5.2-current-page-active/mdbook -o ~/.cargo/bin/mdbook
+      - run: chmod a+x ~/.cargo/bin/mdbook
+      - name: Install mdbook-graphviz
         uses: taiki-e/install-action@v2
         with:
-          tool: mdbook@0.5.2,mdbook-graphviz@0.3.1
+          tool: mdbook-graphviz@0.3.1
       - run: just test-mdbook
       - run: just build-mdbook
       - name: Upload mdbook artifacts

--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -15,7 +15,9 @@ if [ "$(uname)" == "Darwin" ]; then
     dot -V || brew install graphviz
     mdbook-graphviz --version || cargo install mdbook-graphviz@0.3.1 --locked
 else
-    ./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
+    #./mdbook --version || curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.5.2/mdbook-v0.5.2-x86_64-unknown-linux-gnu.tar.gz | tar -xvzf -
+    # This one carries a patch we want
+    ./mdbook --version || ( curl -sSL  https://github.com/jonathanpallant/mdBook/releases/download/v0.5.2-current-page-active/mdbook -o ./mdbook && chmod a+x ./mdbook )
     dot -V || ( curl -ssL https://github.com/restruct/dot-static/raw/refs/heads/master/x64/dot_static -o ./dot && chmod a+x ./dot )
     ./mdbook-graphviz --version || ( curl -sSL https://github.com/dylanowen/mdbook-graphviz/releases/download/v0.3.1/mdbook-graphviz_v0.3.1_x86_64-unknown-linux-musl.zip -o mdbook-graphviz.zip \
         && unzip mdbook-graphviz.zip \


### PR DESCRIPTION
This uses latest mdbook 0.5.2, but with https://github.com/rust-lang/mdBook/pull/2993. The binary was built for x86-64 linux and committed to the tree.

https://github.com/jonathanpallant/mdBook/commit/7e285beb724b1b45e55c92ce7bec4eb3bc1220b0