### PR TITLE
Build some example firmware

### DIFF
--- a/.github/workflows/parallel-build.yml
+++ b/.github/workflows/parallel-build.yml
@@ -118,6 +118,24 @@ jobs:
           tool: flip-link@0.1.10
       - run: just build-radio-app
 
+  build-hal-app:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          cache: nrf52-code/hal-app
+          target: thumbv7em-none-eabihf
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: flip-link@0.1.10
+      - run: just build-hal-app
+      - uses: actions/upload-artifact@v4
+        with:
+          name: blinky
+          path: nrf52-code/hal-app/target/thumbv7em-none-eabihf/release/blinky
+          if-no-files-found: error
+
   build-usb-app:
     runs-on: ubuntu-24.04
     steps:
@@ -184,7 +202,7 @@ jobs:
      runs-on: ubuntu-24.04
      # Notice that because our repo expects all checks to pass, we don't need to include every other job
      # as a dependency of the `deploy` job.
-     needs: [test-build-mdbook, build-dongle-fw]
+     needs: [test-build-mdbook, build-dongle-fw, build-hal-app]
      steps:
        - uses: actions/checkout@v4
        - uses: ./.github/actions/setup
@@ -198,6 +216,10 @@ jobs:
          with:
           name: dongle-fw
           path: ./nrf52-code/dongle-fw/target/thumbv7em-none-eabihf/release/
+       - uses: actions/download-artifact@v4
+         with:
+          name: blinky
+          path: ./nrf52-code/hal-app/target/thumbv7em-none-eabihf/release/
        - run: |
            slug=$(./describe.sh "${GITHUB_REF}")
            echo "Building with slug '${slug}'"
@@ -214,6 +236,6 @@ jobs:
          id: create_release
          uses: ncipollo/release-action@v1
          with:
-           artifacts: "./rust-exercises-${{ env.slug }}.zip,./nrf52-code/dongle-fw/target/thumbv7em-none-eabihf/release/dongle-fw"
+           artifacts: "./rust-exercises-${{ env.slug }}.zip,./nrf52-code/dongle-fw/target/thumbv7em-none-eabihf/release/dongle-fw,./nrf52-code/hal-app/target/thumbv7em-none-eabihf/release/blinky"
            allowUpdates: true
            updateOnlyUnreleased: true

--- a/nrf52-code/boards/dk/src/lib.rs
+++ b/nrf52-code/boards/dk/src/lib.rs
@@ -295,7 +295,31 @@ pub enum Error {
 static HAL_INIT: AtomicBool = AtomicBool::new(false);
 
 /// Initializes the board
+/// 
+/// This version blocks waiting for an RTT connection
 pub fn init() -> Result<Board, Error>{
+    init_with(Default::default())
+}
+
+/// Options you can pass to `init_with`
+#[derive(Debug, Clone, defmt::Format)]
+pub struct InitOptions {
+    /// Should we wait for RTT to connect?
+    /// 
+    /// Defaults to true, so you don't miss any logs. If you build firmware as a
+    /// .hex file to load with drag-and-drop, or if you wish to run the firmware
+    /// on reset with no logged connected, you should set this to false.
+    pub wait_for_rtt: bool
+}
+
+impl Default for InitOptions {
+    fn default() -> Self {
+        Self { wait_for_rtt: true }
+    }
+}
+
+/// Initializes the board with the given options
+pub fn init_with(options: InitOptions) -> Result<Board, Error>{
     if HAL_INIT.swap(true, Ordering::Relaxed) {
         return Err(Error::DoubleInit);
     }
@@ -313,8 +337,10 @@ pub fn init() -> Result<Board, Error>{
     // for waiting for probe-rs to connect.
     //
     // do this *after* clock set-up to avoid start-up issues
-    while !defmt_rtt::in_blocking_mode() {
-        core::hint::spin_loop();
+    if options.wait_for_rtt {
+        while !defmt_rtt::in_blocking_mode() {
+            core::hint::spin_loop();
+        }
     }
 
     // NOTE: this branch runs at most once

--- a/nrf52-code/hal-app/src/bin/blinky.rs
+++ b/nrf52-code/hal-app/src/bin/blinky.rs
@@ -9,9 +9,8 @@ use hal_app as _;
 
 #[entry]
 fn main() -> ! {
-    // to enable more verbose logs, set the `DEFMT_LOG` environment variable.
-
-    let board = dk::init().unwrap();
+    // we don't wait for RTT, so that the LED will blink even without probe-rs
+    let board = dk::init_with(dk::InitOptions { wait_for_rtt: false }).unwrap();
 
     let mut led = board.leds._1;
     let mut timer = board.timer;

--- a/nrf52-code/rust-toolchain.toml
+++ b/nrf52-code/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = [ "llvm-tools-preview", "clippy" ]
+targets = [ "thumbv7em-none-eabihf" ]
+profile = "default"


### PR DESCRIPTION
1. Adds a rust-toolchain.toml file to ensure we get the target libcore and the components we need (makes install instructions easier)
2. Builds the hal-app blinky and puts it in the release area
3. Adds configuration to `dk::init` so we can configure it to not wait for RTT (so the blinky can run without a logger connected)

Closes https://github.com/ferrous-systems/rust-exercises/pull/288
