### PR TITLE
Typo fixes

### DIFF
--- a/exercise-book/src/fundamentals/iterators.md
+++ b/exercise-book/src/fundamentals/iterators.md
@@ -164,7 +164,7 @@ Copy or recreate the [exercise-templates/iterators](../../../exercise-templates/
 
 ### Step 2: Read the string data
 
-Read the contents of `iterators/numbers.txt` line by line, and collect it all into one big `String`. Note that the `lines()` iterator gives us `Result<String, std::io::Error>` so let's only keep the lines that we were able to succesfully read from disk.
+Read the contents of `iterators/numbers.txt` line by line, and collect it all into one big `String`. Note that the `lines()` iterator gives us `Result<String, std::io::Error>` so let's only keep the lines that we were able to successfully read from disk.
 
 <details>
   <summary>Solution</summary>

--- a/exercise-book/src/nrf52/radio-from-scratch.md
+++ b/exercise-book/src/nrf52/radio-from-scratch.md
@@ -56,7 +56,7 @@ script supplied by the `cortex-m-rt` crate).
 ## The `app-template` project template
 
 With all this information you'll be able to build programs for the target device. The [`app-template`] project template provides the most frictionless way to start a new project for the ARM Cortex-M architecture -- for other architectures check out other project templates by the [rust-embedded] organization. It uses
-the [`cargo-generate`] tool to set up a lot of the scafolding and boilerplate necessary
+the [`cargo-generate`] tool to set up a lot of the scaffolding and boilerplate necessary
 for embedded Rust projects.
 
 [rust-embedded]: https://github.com/rust-embedded/

--- a/exercise-solutions/rustlatin/step4/src/lib.rs
+++ b/exercise-solutions/rustlatin/step4/src/lib.rs
@@ -52,6 +52,6 @@ fn correct_translation() {
 #[test]
 fn task() {
     let sentence = "Implement a function that splits a sentence into its words";
-    let setence_latinized = rustlatin(sentence);
-    assert_eq!(setence_latinized, "srImplement sra functionrs thatrs splitsrs sra sentencers srinto srits wordsrs");
+    let sentence_latinized = rustlatin(sentence);
+    assert_eq!(sentence_latinized, "srImplement sra functionrs thatrs splitsrs sra sentencers srinto srits wordsrs");
 }

--- a/nrf52-code/boards/dk-solution/src/radio.rs
+++ b/nrf52-code/boards/dk-solution/src/radio.rs
@@ -403,7 +403,7 @@ impl<'d> Radio<'d> {
     pub fn recv(&mut self, packet: &mut Packet) -> Result<u16, u16> {
         // Start non-blocking receive
         self.recv_non_blocking(packet, |recv| {
-            // Block untill receive is done
+            // Block until receive is done
             nb::block!(recv.is_done())
         })
     }
@@ -451,7 +451,7 @@ impl<'d> Radio<'d> {
 
         // Start non-blocking receive
         self.recv_non_blocking(packet, |recv| {
-            // Check if either receive is done or timeout occured
+            // Check if either receive is done or timeout occurred
             loop {
                 match recv.is_done() {
                     Ok(crc) => {

--- a/nrf52-code/boards/dk/src/radio.rs
+++ b/nrf52-code/boards/dk/src/radio.rs
@@ -403,7 +403,7 @@ impl<'d> Radio<'d> {
     pub fn recv(&mut self, packet: &mut Packet) -> Result<u16, u16> {
         // Start non-blocking receive
         self.recv_non_blocking(packet, |recv| {
-            // Block untill receive is done
+            // Block until receive is done
             nb::block!(recv.is_done())
         })
     }
@@ -451,7 +451,7 @@ impl<'d> Radio<'d> {
 
         // Start non-blocking receive
         self.recv_non_blocking(packet, |recv| {
-            // Check if either receive is done or timeout occured
+            // Check if either receive is done or timeout occurred
             loop {
                 match recv.is_done() {
                     Ok(crc) => {


### PR DESCRIPTION
There's 2 remaining (non-noisy) typos detected by `typos-cli` in this repo:

```
error: `occured` should be `occurred`
   ╭▸ ./exercise-book/src/nrf52/troubleshoot-cargo-run-error.md:11:42
   │
11 │ Error: An error specific to a probe type occured: USB error while taking control over USB device: Access denied (insufficient permissions)
   ╰╴                                         ━━━━━━━
error: `occured` should be `occurred`
   ╭▸ ./exercise-book/src/nrf52/troubleshoot-cargo-run-error.md:20:42
   │
20 │ Error: An error specific to a probe type occured: USB error while taking control over USB device: Resource busy
   ╰╴                                         ━━━━━━━
```

but since those are error messages I'll punt to y'all on if they should be left alone.