### PR TITLE
switch from llvm-tools-preview to llvm-tools

### DIFF
--- a/nrf52-code/rust-toolchain.toml
+++ b/nrf52-code/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
 channel = "stable"
-components = [ "llvm-tools-preview", "clippy" ]
+components = [ "llvm-tools", "clippy" ]
 targets = [ "thumbv7em-none-eabihf" ]
 profile = "default"


### PR DESCRIPTION
I am still trying to figure out what the different between those 2 is.

UPDATE: Found https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/llvm-tools.20stabilization . 
Maybe we should just keep the -preview suffix.